### PR TITLE
Guard persistence error logs for release builds

### DIFF
--- a/Kukulcan/CollectionStore.swift
+++ b/Kukulcan/CollectionStore.swift
@@ -73,7 +73,9 @@ final class CollectionStore: ObservableObject {
             let data = try JSONEncoder().encode(owned)
             ownedData = data
         } catch {
+#if DEBUG
             print("Erreur d’encodage des cartes possédées: \(error)")
+#endif
         }
     }
 
@@ -83,7 +85,9 @@ final class CollectionStore: ObservableObject {
             let arr = try JSONDecoder().decode([Card].self, from: ownedData)
             owned = arr
         } catch {
+#if DEBUG
             print("Erreur de décodage des cartes possédées: \(error)")
+#endif
         }
     }
 

--- a/KukulcanTests/KukulcanTests.swift
+++ b/KukulcanTests/KukulcanTests.swift
@@ -10,8 +10,12 @@ import Testing
 
 struct KukulcanTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    /// Vérifie la logique pierre-feuille-ciseaux entre les éléments.
+    @Test func elementBeatsLogic() {
+        #expect(Element.fire.beats(.plant))
+        #expect(Element.water.beats(.fire))
+        #expect(Element.plant.beats(.water))
+        #expect(!Element.fire.beats(.water))
     }
 
 }


### PR DESCRIPTION
## Summary
- Log collection encoding/decoding failures only in debug builds
- Replace placeholder test with checks for Element battle logic

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0e1d00bc832b90fbf426f9a99bbf