### PR TITLE
Ensure combat card actions and background render properly

### DIFF
--- a/Kukulcan/CardView.swift
+++ b/Kukulcan/CardView.swift
@@ -40,7 +40,8 @@ struct CardView: View {
     var body: some View {
         let h = width * ratio
 
-        ZStack {
+        // Contenu principal de la carte
+        let core = ZStack {
             // Fond / cadre carte
             RoundedRectangle(cornerRadius: 18)
                 .fill(.ultraThinMaterial)
@@ -72,7 +73,6 @@ struct CardView: View {
                         CardBackView()
                             .frame(width: width, height: h - topHeight - bottomHeight)
                     }
-
                 }
 
                 // Bandeau bas (effet)
@@ -86,7 +86,15 @@ struct CardView: View {
         }
         .frame(width: width, height: h)
         .contentShape(RoundedRectangle(cornerRadius: 18))
-        .onTapGesture { onTap?() }
+
+        // N’applique le geste de tap que si un callback existe.
+        return Group {
+            if let onTap {
+                core.onTapGesture { onTap() }
+            } else {
+                core
+            }
+        }
     }
 
     // MARK: - Layout helpers

--- a/Kukulcan/CombatView.swift
+++ b/Kukulcan/CombatView.swift
@@ -23,28 +23,33 @@ struct CombatView: View {
     @State private var attackFromSlot: Int? = nil  // -1 = dieu
 
     var body: some View {
-        VStack(spacing: 10) {
-            header
+        ZStack {
+            // Fond visuel du combat
+            CombatBackground()
 
-            // Opposant (aperçu simple)
-            opponentStrip
+            VStack(spacing: 10) {
+                header
 
-            Divider().opacity(0.3)
+                // Opposant (aperçu simple)
+                opponentStrip
 
-            // Board du joueur (4 slots)
-            boardArea
+                Divider().opacity(0.3)
 
-            // Zone Dieu + Sacrifice + Défausse
-            zonesRow
+                // Board du joueur (4 slots)
+                boardArea
 
-            // Main du joueur
-            handStrip
+                // Zone Dieu + Sacrifice + Défausse
+                zonesRow
 
-            // Log + actions de tour
-            footerControls
+                // Main du joueur
+                handStrip
+
+                // Log + actions de tour
+                footerControls
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 8)
         }
-        .padding(.horizontal, 12)
-        .padding(.top, 8)
         .onAppear {
             // Démarrer la partie si pas déjà fait
             if engine.p1.hand.isEmpty && engine.p2.hand.isEmpty {

--- a/Kukulcan/Rules.swift
+++ b/Kukulcan/Rules.swift
@@ -374,7 +374,7 @@ struct StarterFactory {
         // Dieux (tes assets existants)
         d += [god("Ix Chel", atk: 6, hp: 7, el: .water, img: "ix_chel", cost: 7,
                   lore: "Déesse de la lune et des marées, elle ourdit les destins comme on tisse un voile d’argent.")]
-        d += [god("Kukulcan", atk: 7, hp: 8, el: .plant, img: "kuklcan", cost: 7,
+        d += [god("Kukulcan", atk: 7, hp: 8, el: .plant, img: "kukulcan", cost: 7,
                   lore: "Serpent à plumes, cyclone vivant des jungles oubliées.")]
         return d
     }


### PR DESCRIPTION
## Summary
- Show the jungle combat background in `CombatView`
- Allow action menus on `CardView` by avoiding empty tap gestures
- Correct Kukulcan card image reference

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0fe16e80832b815caeef60637748