### PR TITLE
Adapt card and board scaling for small devices

### DIFF
--- a/Kukulcan/CardView.swift
+++ b/Kukulcan/CardView.swift
@@ -37,6 +37,12 @@ struct CardView: View {
 
     private let ratio: CGFloat = 1.5
 
+    // Tailles de police adaptatives
+    private var typeFont: Font { .system(size: width * 0.08, weight: .bold) }
+    private var nameFont: Font { .system(size: width * 0.12, weight: .semibold) }
+    private var statFont: Font { .system(size: width * 0.12, weight: .bold) }
+    private var effectFont: Font { .system(size: width * 0.10) }
+
     var body: some View {
         let h = width * ratio
 
@@ -106,16 +112,16 @@ struct CardView: View {
         HStack(spacing: 8) {
             // Type
             Text(card.rarity == .legendary ? "DIEU" : cardTypeText)
-                .font(.caption2.bold())
+                .font(typeFont)
                 .padding(.horizontal, 8).padding(.vertical, 4)
                 .background(Capsule().fill(typeChipBG))
                 .foregroundStyle(.white)
 
             // Nom
             Text(card.name)
-                .font(.headline)
+                .font(nameFont)
                 .lineLimit(1)
-                .minimumScaleFactor(0.7)
+                .minimumScaleFactor(0.5)
                 .foregroundStyle(.white)
 
             Spacer()
@@ -124,7 +130,7 @@ struct CardView: View {
             HStack(spacing: 4) {
                 Image(systemName: elementIcon)
                 Text("\(card.attack)/\(card.health)")
-                    .font(.headline.bold())
+                    .font(statFont)
             }
             .foregroundStyle(.white)
             .padding(.horizontal, 8).padding(.vertical, 4)
@@ -137,10 +143,10 @@ struct CardView: View {
     private var footer: some View {
         HStack {
             Text(card.effect ?? "")
-                .font(.footnote)
+                .font(effectFont)
                 .foregroundStyle(.white.opacity(0.95))
                 .lineLimit(1)
-                .minimumScaleFactor(0.7)
+                .minimumScaleFactor(0.5)
             Spacer(minLength: 0)
         }
         .padding(.horizontal, 10)

--- a/Kukulcan/ContentView.swift
+++ b/Kukulcan/ContentView.swift
@@ -22,9 +22,12 @@ struct ContentView: View {
             GeometryReader { geo in
                 // Tailles adaptatives
                 let W = geo.size.width
-                let cardW = min(150, max(110, W * 0.32))      // cartes de la main
-                let laneCardW = cardW * 0.9                   // cartes posées
-                let laneBoxW = laneCardW + 30
+                let lanes = 3
+                let hPad: CGFloat = 8
+                let spacing: CGFloat = 12
+                let laneBoxW = (W - hPad*2 - spacing*CGFloat(lanes - 1)) / CGFloat(lanes)
+                let laneCardW = laneBoxW - 30
+                let cardW = laneCardW / 0.9                   // cartes de la main
                 let laneBoxH = laneCardW * 1.5 + 30
 
                 VStack(spacing: 8) {
@@ -44,71 +47,69 @@ struct ContentView: View {
                         .minimumScaleFactor(0.6)
                         .padding(.bottom, 4)
 
-                    // Lanes (scroll horizontal si nécessaire)
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 12) {
-                            ForEach(0..<3) { i in
-                                VStack(spacing: 6) {
-                                    Text("Lane \(i+1)").font(.caption)
+                    // Lanes
+                    HStack(spacing: spacing) {
+                        ForEach(0..<3) { i in
+                            VStack(spacing: 6) {
+                                Text("Lane \(i+1)").font(.caption)
 
-                                    ZStack {
-                                        let isSelected = (selectedLane == i)
-                                        let isTargeted = (targetedLane == i)
+                                ZStack {
+                                    let isSelected = (selectedLane == i)
+                                    let isTargeted = (targetedLane == i)
 
-                                        RoundedRectangle(cornerRadius: 12)
-                                            .fill(.ultraThinMaterial) // lisibilité
-                                            .overlay(
-                                                RoundedRectangle(cornerRadius: 12)
-                                                    .stroke(
-                                                        isTargeted ? .blue :
-                                                        (isSelected ? .blue : .secondary),
-                                                        style: StrokeStyle(lineWidth: isTargeted ? 3 : 2, dash: [6,4])
-                                                    )
-                                            )
-                                            .frame(width: laneBoxW, height: laneBoxH)
-                                            .contentShape(Rectangle())
-                                            .onTapGesture { selectedLane = i }
-                                            .dropDestination(for: Card.self) { items, _ in
-                                                guard let card = items.first else { return false }
-                                                withAnimation(.easeInOut) {
-                                                    game.play(card: card, to: i)
-                                                    selectedLane = nil
-                                                }
-                                                return true
-                                            } isTargeted: { over in
-                                                targetedLane = over ? i : (targetedLane == i ? nil : targetedLane)
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .fill(.ultraThinMaterial) // lisibilité
+                                        .overlay(
+                                            RoundedRectangle(cornerRadius: 12)
+                                                .stroke(
+                                                    isTargeted ? .blue :
+                                                    (isSelected ? .blue : .secondary),
+                                                    style: StrokeStyle(lineWidth: isTargeted ? 3 : 2, dash: [6,4])
+                                                )
+                                        )
+                                        .frame(width: laneBoxW, height: laneBoxH)
+                                        .contentShape(Rectangle())
+                                        .onTapGesture { selectedLane = i }
+                                        .dropDestination(for: Card.self) { items, _ in
+                                            guard let card = items.first else { return false }
+                                            withAnimation(.easeInOut) {
+                                                game.play(card: card, to: i)
+                                                selectedLane = nil
                                             }
+                                            return true
+                                        } isTargeted: { over in
+                                            targetedLane = over ? i : (targetedLane == i ? nil : targetedLane)
+                                        }
 
-                                        VStack {
-                                            // Carte IA
-                                            if let ai = game.lanes[i].ai {
-                                                CardView(card: ai, faceUp: true, width: laneCardW) {
-                                                    selectedCard = ai   // tap = zoom
-                                                }
-                                                .scaleEffect(0.98)
-                                            } else {
-                                                Text("IA").foregroundStyle(.secondary)
+                                    VStack {
+                                        // Carte IA
+                                        if let ai = game.lanes[i].ai {
+                                            CardView(card: ai, faceUp: true, width: laneCardW) {
+                                                selectedCard = ai   // tap = zoom
                                             }
+                                            .scaleEffect(0.98)
+                                        } else {
+                                            Text("IA").foregroundStyle(.secondary)
+                                        }
 
-                                            Spacer().frame(height: 8)
+                                        Spacer().frame(height: 8)
 
-                                            // Carte Joueur
-                                            if let p = game.lanes[i].player {
-                                                CardView(card: p, faceUp: true, width: laneCardW) {
-                                                    selectedCard = p    // tap = zoom
-                                                }
-                                                .scaleEffect(0.98)
-                                            } else {
-                                                Text("Toi").foregroundStyle(.secondary)
+                                        // Carte Joueur
+                                        if let p = game.lanes[i].player {
+                                            CardView(card: p, faceUp: true, width: laneCardW) {
+                                                selectedCard = p    // tap = zoom
                                             }
+                                            .scaleEffect(0.98)
+                                        } else {
+                                            Text("Toi").foregroundStyle(.secondary)
                                         }
                                     }
                                 }
-                                .frame(width: laneBoxW)
                             }
+                            .frame(width: laneBoxW)
                         }
-                        .padding(.horizontal, 8)
                     }
+                    .padding(.horizontal, hPad)
                     .frame(height: laneBoxH + 30)
 
                     Spacer(minLength: 4)


### PR DESCRIPTION
## Summary
- scale card fonts based on card width so text fits on smaller cards
- compute board and card dimensions from available width to show entire combat area

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1582c42c832b9b537fa72c824419