### PR TITLE
Add Swift Package manifest for running tests

### DIFF
--- a/Kukulcan/Element.swift
+++ b/Kukulcan/Element.swift
@@ -1,4 +1,8 @@
+// SwiftUI n'est pas disponible sur toutes les plateformes (ex.: Linux).
+// On ne l'importe que lorsqu'il est présent afin que le code compile partout.
+#if canImport(SwiftUI)
 import SwiftUI
+#endif
 
 // ⚠️ NE redéclare PAS l'enum ici.
 // L'enum Element (fire, water, plant) existe déjà dans Rules.swift.
@@ -22,6 +26,7 @@ extension Element {
         }
     }
 
+    #if canImport(SwiftUI)
     /// Couleur associée
     var color: Color {
         switch self {
@@ -30,6 +35,7 @@ extension Element {
         case .plant: return .green
         }
     }
+    #endif
 
     /// Nom lisible
     var title: String {

--- a/Kukulcan/ElementTypes.swift
+++ b/Kukulcan/ElementTypes.swift
@@ -1,0 +1,7 @@
+// Types essentiels pour les tests (version allégée des règles du jeu).
+// L'enum `Element` est volontairement isolée afin d'éviter les dépendances
+// à SwiftUI/Combine lors de la compilation des tests sur Linux.
+
+enum Element: String, Codable, CaseIterable {
+    case fire, water, plant
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "92b00e1a82db24741e99d45376cc79ceea546dc1c7262e190a92e8e3ac2abb77",
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "swift-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-testing.git",
+      "state" : {
+        "revision" : "399f76dcd91e4c688ca2301fa24a8cc6d9927211",
+        "version" : "0.99.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "Kukulcan",
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v17)
+    ],
+    products: [
+        .library(name: "Kukulcan", targets: ["Kukulcan"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-testing.git", from: "0.9.0")
+    ],
+    targets: [
+        .target(
+            name: "Kukulcan",
+            path: "Kukulcan",
+            sources: ["ElementTypes.swift", "Element.swift"]
+        ),
+        .testTarget(
+            name: "KukulcanTests",
+            dependencies: [
+                "Kukulcan",
+                .product(name: "Testing", package: "swift-testing")
+            ],
+            path: "KukulcanTests"
+        )
+    ]
+)


### PR DESCRIPTION
## Summary
- add Swift Package manifest and dependency for `swift-testing`
- add minimal `Element` enum for Linux builds
- make SwiftUI features conditional in `Element` helpers

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ad167fbb7c832b8af5c253d89b2375