### PR TITLE
Fix combat layout and show card details on tap

### DIFF
--- a/Kukulcan/CombatView.swift
+++ b/Kukulcan/CombatView.swift
@@ -22,6 +22,8 @@ struct CombatView: View {
     @State private var showAttackPicker = false
     @State private var attackFromSlot: Int? = nil  // -1 = dieu
 
+    @State private var selectedCard: Card? = nil
+
     var body: some View {
         ZStack {
             // Fond visuel du combat
@@ -41,11 +43,7 @@ struct CombatView: View {
                 // Zone Dieu + Sacrifice + Défausse
                 zonesRow
 
-                // Main du joueur
-                handStrip
-
-                // Log + actions de tour
-                footerControls
+                Spacer(minLength: 0)
             }
             .padding(.horizontal, 12)
             .padding(.top, 8)
@@ -66,6 +64,18 @@ struct CombatView: View {
         }
         .navigationTitle("Combats")
         .navigationBarTitleDisplayMode(.inline)
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: 8) {
+                footerControls
+                handStrip
+            }
+            .padding(.horizontal, 12)
+            .padding(.bottom, 4)
+            .background(.ultraThinMaterial)
+        }
+        .fullScreenCover(item: $selectedCard) { card in
+            CardDetailView(card: card) { selectedCard = nil }
+        }
     }
 
     // MARK: - Header (scores / sang)
@@ -181,9 +191,11 @@ struct CombatView: View {
                 Text("Sacrifice").font(.caption).foregroundStyle(.secondary)
                 // visuel tourné à 90° si présent
                 if let inst = engine.current.sacrificeSlot {
-                    CardView(card: inst.base, faceUp: true, width: 92)
-                        .rotationEffect(.degrees(90))
-                        .overlay(Text("+1 Sang").font(.caption2.bold()).padding(4).background(.black.opacity(0.6)).clipShape(Capsule()).foregroundStyle(.white), alignment: .bottom)
+                    CardView(card: inst.base, faceUp: true, width: 92) {
+                        selectedCard = inst.base
+                    }
+                    .rotationEffect(.degrees(90))
+                    .overlay(Text("+1 Sang").font(.caption2.bold()).padding(4).background(.black.opacity(0.6)).clipShape(Capsule()).foregroundStyle(.white), alignment: .bottom)
                 } else {
                     emptySlot(width: 92, height: 128)
                 }
@@ -214,12 +226,14 @@ struct CombatView: View {
                 HStack(spacing: 10) {
                     ForEach(engine.current.hand.indices, id: \.self) { idx in
                         let c = engine.current.hand[idx]
-                        CardView(card: c, faceUp: true, width: 120) {}
-                            .draggable(c)
-                            .overlay(alignment: .bottom) {
-                                actionButtonsForHandCard(c, index: idx)
-                                    .padding(.bottom, 6)
-                            }
+                        CardView(card: c, faceUp: true, width: 120) {
+                            selectedCard = c
+                        }
+                        .draggable(c)
+                        .overlay(alignment: .bottom) {
+                            actionButtonsForHandCard(c, index: idx)
+                                .padding(.bottom, 6)
+                        }
                     }
                 }
                 .padding(.horizontal, 4)
@@ -288,17 +302,19 @@ struct CombatView: View {
     private func slotView(for card: Card?, hp: Int?) -> some View {
         ZStack {
             if let card {
-                CardView(card: card, faceUp: true, width: 92) {}
-                    .overlay(alignment: .bottomTrailing) {
-                        if let hp {
-                            Text("\(hp)❤︎")
-                                .font(.caption2.bold())
-                                .padding(6)
-                                .background(.black.opacity(0.6))
-                                .foregroundStyle(.white)
-                                .clipShape(Capsule())
-                                .padding(4)
-                        }
+                CardView(card: card, faceUp: true, width: 92) {
+                    selectedCard = card
+                }
+                .overlay(alignment: .bottomTrailing) {
+                    if let hp {
+                        Text("\(hp)❤︎")
+                            .font(.caption2.bold())
+                            .padding(6)
+                            .background(.black.opacity(0.6))
+                            .foregroundStyle(.white)
+                            .clipShape(Capsule())
+                            .padding(4)
+                    }
                     }
             } else {
                 emptySlot(width: 92, height: 128)

--- a/Kukulcan/PackOpeningView.swift
+++ b/Kukulcan/PackOpeningView.swift
@@ -10,6 +10,7 @@ struct PackOpeningView: View {
     @State private var packScale: CGFloat = 1.0
     @State private var packOpacity: Double = 1.0
     @State private var burst: Double = 0.0
+    @State private var selectedCard: Card? = nil
 
     var body: some View {
         ZStack {
@@ -30,6 +31,9 @@ struct PackOpeningView: View {
         }
         .animation(.default, value: stage)
         .animation(.default, value: showCards)
+        .fullScreenCover(item: $selectedCard) { card in
+            CardDetailView(card: card) { selectedCard = nil }
+        }
     }
 }
 
@@ -94,9 +98,11 @@ private extension PackOpeningView {
     @ViewBuilder
     func cardSlot(index i: Int) -> some View {
         if i < cards.count, showCards[i] {
-            CardView(card: cards[i], faceUp: true, width: 120)
-                .transition(.scale.combined(with: .opacity))
-                .shadow(color: cards[i].rarity.glow, radius: 14)
+            CardView(card: cards[i], faceUp: true, width: 120) {
+                selectedCard = cards[i]
+            }
+            .transition(.scale.combined(with: .opacity))
+            .shadow(color: cards[i].rarity.glow, radius: 14)
         } else {
             PlaceholderCard(width: 120, height: 180)
         }

--- a/Kukulcan/PacksView.swift
+++ b/Kukulcan/PacksView.swift
@@ -7,6 +7,7 @@ struct PacksView: View {
     @State private var showOpening = false
     @State private var pulse = false
     @State private var bloodProgress: CGFloat = 0
+    @State private var selectedCard: Card? = nil
 
     var body: some View {
         NavigationStack {
@@ -59,9 +60,11 @@ struct PacksView: View {
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack(spacing: 12) {
                             ForEach(lastPulled) { card in
-                                CardView(card: card, faceUp: true, width: 120) { }
-                                    .transition(.scale.combined(with: .opacity))
-                                    .shadow(color: card.rarity.glow, radius: 10)
+                                CardView(card: card, faceUp: true, width: 120) {
+                                    selectedCard = card
+                                }
+                                .transition(.scale.combined(with: .opacity))
+                                .shadow(color: card.rarity.glow, radius: 10)
                             }
                         }
                         .padding(.horizontal)
@@ -103,6 +106,9 @@ struct PacksView: View {
             withAnimation(.easeInOut(duration: 0.6)) { bloodProgress = 0.0 }
         }) {
             PackOpeningView(cards: lastPulled) { showOpening = false }
+        }
+        .fullScreenCover(item: $selectedCard) { card in
+            CardDetailView(card: card) { selectedCard = nil }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Move combat hand and controls into a bottom inset so board slots stay visible on phones
- Open detailed card view from Packs and Pack Opening screens
- Allow tapping any card in combat to show its details

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ad248db6f4832b93351ca2040848d9