### PR TITLE
Use player collection for combat deck and require 10 cards

### DIFF
--- a/Kukulcan/CollectionStore.swift
+++ b/Kukulcan/CollectionStore.swift
@@ -13,11 +13,6 @@ final class CollectionStore: ObservableObject {
 
     init() {
         load()
-        // Si première ouverture et collection vide, on peut donner 3 communes de départ (optionnel)
-        if owned.isEmpty {
-            let starters = Array(CardsDB.commons.shuffled().prefix(3))
-            owned.append(contentsOf: starters)
-        }
     }
 
     // MARK: - Packs

--- a/Kukulcan/MainTabView.swift
+++ b/Kukulcan/MainTabView.swift
@@ -11,8 +11,19 @@ struct MainTabView: View {
             CollectionView()
                 .tabItem { Label("Collection", systemImage: "square.grid.2x2.fill") }
 
-            CombatView()
+            if collection.ownedPlayable.count >= 10 {
+                CombatView(
+                    engine: GameEngine(
+                        p1: PlayerState(name: "Toi", deck: collection.ownedPlayable),
+                        p2: PlayerState(name: "IA", deck: StarterFactory.randomDeck())
+                    )
+                )
                 .tabItem { Label("Combats", systemImage: "gamecontroller.fill") }
+            } else {
+                Text("Tu as besoin d'au moins 10 cartes pour combattre.")
+                    .padding()
+                    .tabItem { Label("Combats", systemImage: "gamecontroller.fill") }
+            }
         }
         .tint(.orange)
     }


### PR DESCRIPTION
## Summary
- Start the game with an empty collection
- Use the player's collection as the combat deck and block fights without at least 10 playable cards

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68ad25c7079c832b93e9e68cbc9111dd