### PR TITLE
Require effect for all cards and add unique god effects

### DIFF
--- a/Kukulcan/CardDetailView.swift
+++ b/Kukulcan/CardDetailView.swift
@@ -90,7 +90,7 @@ struct CardDetailView: View {
 
                             // Bandeau bas (texte d’effet)
                             HStack {
-                                Text(card.effect ?? "")
+                                Text(card.effect)
                                     .font(.footnote)
                                     .foregroundStyle(.white.opacity(0.95))
                                     .lineLimit(2)

--- a/Kukulcan/CardView.swift
+++ b/Kukulcan/CardView.swift
@@ -142,7 +142,7 @@ struct CardView: View {
 
     private var footer: some View {
         HStack {
-            Text(card.effect ?? "")
+            Text(card.effect)
                 .font(effectFont)
                 .foregroundStyle(.white.opacity(0.95))
                 .lineLimit(1)

--- a/Kukulcan/CardsDatabase.swift
+++ b/Kukulcan/CardsDatabase.swift
@@ -23,7 +23,7 @@ struct CardsDB {
         atk: Int,
         hp: Int,
         img: String,
-        effect: String? = nil,
+        effect: String,
         lore: String? = nil
     ) -> Card {
         Card(
@@ -68,6 +68,7 @@ struct CardsDB {
         hp: Int,
         img: String,
         bloodCost: Int = 7,
+        effect: String,
         lore: String
     ) -> Card {
         Card(
@@ -79,7 +80,7 @@ struct CardsDB {
             health: hp,
             ritual: nil,
             bloodCost: bloodCost,
-            effect: "Invocation : pouvoir divin.",
+            effect: effect,
             lore: lore
         )
     }
@@ -95,18 +96,22 @@ struct CardsDB {
         common("Jeune chasseur",
                atk: 2, hp: 1,
                img: "jeune_chasseur",
+               effect: "Arrivée : pioche 1.",
                lore: "Encore naïf, il croit pouvoir survivre à l’épreuve."),
         common("Prisonnier captif",
                atk: 1, hp: 2,
                img: "prisonnier_captif",
+               effect: "Mort : +1 sang.",
                lore: "Ses chaînes résonnent comme un chant d’offrande."),
         common("Guerrier blessé",
                atk: 2, hp: 3,
                img: "guerrier_blesse",
+               effect: "Arrivée : gagne +1 PV.",
                lore: "Le sang qui s’écoule de sa plaie est déjà une offrande."),
         common("Éclaireur perdu",
                atk: 1, hp: 2,
                img: "eclaireur_perdu",
+               effect: "Sacrifice : pioche 1.",
                lore: "Isolé dans la jungle, il devient proie autant que soldat."),
         common("Archer maladroit",
                atk: 2, hp: 2,
@@ -154,26 +159,32 @@ struct CardsDB {
         god("Kinich Ahau",
             atk: 7, hp: 7,
             img: "kinich_ahau",
+            effect: "Invocation : brûle les impies.",
             lore: "Le soleil brûlant de Kinich Ahau éclaire la jungle et châtie ses ennemis d’une chaleur implacable."),
         god("Kukulcan",
             atk: 7, hp: 8,
             img: "kukulcan",                      // ⚠️ bien orthographié
+            effect: "Invocation : le serpent à plumes se déchaîne.",
             lore: "Le serpent à plumes s’élève dans le vent et fauche les orgueilleux d’un seul souffle."),
         god("Chaac",
             atk: 6, hp: 7,
             img: "chaac",
+            effect: "Invocation : la pluie et la foudre répondent.",
             lore: "Le tonnerre gronde avec Chaac, et chaque éclair abreuve tout… ou foudroie les impies."),
         god("Ix Chel",
             atk: 6, hp: 7,
             img: "ix_chel",
+            effect: "Invocation : voile lunaire.",
             lore: "Déesse de la lune et des marées, elle ourdit les destins comme on tisse un voile d’argent."),
         god("Itzamna",
             atk: 5, hp: 7,
             img: "itzamna",
+            effect: "Invocation : sagesse des origines.",
             lore: "Seigneur du ciel et des écritures, il murmure la naissance et la fin des mondes."),
         god("Buluc Chabtan",
             atk: 6, hp: 6,
             img: "buluc_chabtan",
+            effect: "Invocation : héraut de la guerre.",
             lore: "La guerre est sa prière ; il exige des cœurs ardents et offre la victoire en retour.")
     ]
 

--- a/Kukulcan/Rules.swift
+++ b/Kukulcan/Rules.swift
@@ -28,7 +28,7 @@ struct Card: Identifiable, Codable, Hashable {
 
     // Coûts / mécaniques
     let bloodCost: Int    // coût d’invocation pour un dieu (sinon 0)
-    let effect: String?   // texte synthétique à afficher sur la carte (footer)
+    let effect: String    // texte synthétique à afficher sur la carte (footer)
     let lore: String?     // visible seulement en vue zoom
 
     init(name: String,
@@ -39,7 +39,7 @@ struct Card: Identifiable, Codable, Hashable {
          health: Int = 0,
          ritual: RitualKind? = nil,
          bloodCost: Int = 0,
-         effect: String? = nil,
+         effect: String,
          lore: String? = nil) {
         self.name = name
         self.type = type
@@ -364,7 +364,7 @@ final class GameEngine: ObservableObject {
 // MARK: - Sample Decks (starter)
 
 struct StarterFactory {
-    static func common(_ name: String, atk: Int, hp: Int, img: String, effect: String? = nil) -> Card {
+    static func common(_ name: String, atk: Int, hp: Int, img: String, effect: String) -> Card {
         Card(name: name, type: .common, rarity: .common, imageName: img,
              attack: atk, health: hp, effect: effect, lore: nil)
     }
@@ -372,9 +372,9 @@ struct StarterFactory {
         Card(name: name, type: .ritual, rarity: .rare, imageName: img,
              ritual: kind, effect: effect)
     }
-    static func god(_ name: String, atk: Int, hp: Int, img: String, cost: Int, lore: String) -> Card {
+    static func god(_ name: String, atk: Int, hp: Int, img: String, cost: Int, effect: String, lore: String) -> Card {
         Card(name: name, type: .god, rarity: .legendary, imageName: img,
-             attack: atk, health: hp, bloodCost: cost, effect: "Invocation : pouvoir divin.", lore: lore)
+             attack: atk, health: hp, bloodCost: cost, effect: effect, lore: lore)
     }
 
     static func playerDeck() -> [Card] {
@@ -382,10 +382,14 @@ struct StarterFactory {
         // Communes (utilise les noms d’assets que tu as)
         d += Array(repeating: common("Villageois effrayé", atk: 1, hp: 1, img: "villageois_effraye",
                                      effect: "Sacrifice : +1 sang."), count: 3)
-        d += Array(repeating: common("Jeune chasseur", atk: 2, hp: 1, img: "jeune_chasseur"), count: 2)
-        d += Array(repeating: common("Prisonnier captif", atk: 1, hp: 2, img: "prisonnier_captif"), count: 2)
-        d += [common("Guerrier blessé", atk: 2, hp: 3, img: "guerrier_blesse")]
-        d += [common("Éclaireur perdu", atk: 1, hp: 2, img: "eclaireur_perdu")]
+        d += Array(repeating: common("Jeune chasseur", atk: 2, hp: 1, img: "jeune_chasseur",
+                                     effect: "Arrivée : pioche 1."), count: 2)
+        d += Array(repeating: common("Prisonnier captif", atk: 1, hp: 2, img: "prisonnier_captif",
+                                     effect: "Mort : +1 sang."), count: 2)
+        d += [common("Guerrier blessé", atk: 2, hp: 3, img: "guerrier_blesse",
+                     effect: "Arrivée : gagne +1 PV.")]
+        d += [common("Éclaireur perdu", atk: 1, hp: 2, img: "eclaireur_perdu",
+                     effect: "Sacrifice : pioche 1.")]
         d += [common("Archer maladroit", atk: 2, hp: 2, img: "archer_maladroit",
                      effect: "Si tue une carte : pioche 1.")]
 
@@ -396,8 +400,10 @@ struct StarterFactory {
 
         // Dieux (tes assets existants)
         d += [god("Ix Chel", atk: 6, hp: 7, img: "ix_chel", cost: 7,
+                  effect: "Invocation : voile lunaire.",
                   lore: "Déesse de la lune et des marées, elle ourdit les destins comme on tisse un voile d’argent.")]
         d += [god("Kukulcan", atk: 7, hp: 8, img: "kukulcan", cost: 7,
+                  effect: "Invocation : le serpent à plumes se déchaîne.",
                   lore: "Serpent à plumes, cyclone vivant des jungles oubliées.")]
         return d
     }


### PR DESCRIPTION
## Summary
- Make card effect non-optional and update views to display it
- Give every common card an effect and provide distinctive effects for gods
- Ensure starter decks and database enforce effects on all cards

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ad285ff168832b99545644b455c2b0