### PR TITLE
Add deck creation and selection

### DIFF
--- a/Kukulcan/CollectionStore.swift
+++ b/Kukulcan/CollectionStore.swift
@@ -5,14 +5,21 @@ import SwiftUI
 final class CollectionStore: ObservableObject {
     // Persistance locale
     @AppStorage("owned_cards_v2") private var ownedData: Data = Data()
+    @AppStorage("player_decks_v1") private var decksData: Data = Data()
 
     // Cartes possédées
     @Published var owned: [Card] = [] {
         didSet { save() }
     }
 
+    // Decks du joueur (max 20)
+    @Published var decks: [Deck] = [] {
+        didSet { saveDecks() }
+    }
+
     init() {
         load()
+        loadDecks()
     }
 
     // MARK: - Packs
@@ -86,10 +93,34 @@ final class CollectionStore: ObservableObject {
         }
     }
 
+    private func saveDecks() {
+        do {
+            let data = try JSONEncoder().encode(decks)
+            decksData = data
+        } catch {
+#if DEBUG
+            print("Erreur d’encodage des decks: \(error)")
+#endif
+        }
+    }
+
+    private func loadDecks() {
+        guard !decksData.isEmpty else { return }
+        do {
+            let arr = try JSONDecoder().decode([Deck].self, from: decksData)
+            decks = arr
+        } catch {
+#if DEBUG
+            print("Erreur de décodage des decks: \(error)")
+#endif
+        }
+    }
+
     // MARK: - Debug / Reset
 
     func resetCollection() {
         owned.removeAll()
+        decks.removeAll()
     }
 }
 

--- a/Kukulcan/CollectionView.swift
+++ b/Kukulcan/CollectionView.swift
@@ -70,6 +70,13 @@ struct CollectionView: View {
                 }
             }
             .navigationTitle("Collection")
+            .toolbar {
+                NavigationLink {
+                    DecksView()
+                } label: {
+                    Label("Decks", systemImage: "folder")
+                }
+            }
             // ⬇︎ Place le fond derrière tout le contenu de la stack
             .background(
                 CollectionBackground()

--- a/Kukulcan/Deck.swift
+++ b/Kukulcan/Deck.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct Deck: Identifiable, Codable, Hashable {
+    var id: UUID = UUID()
+    var name: String
+    var cards: [Card]
+}
+

--- a/Kukulcan/DeckEditorView.swift
+++ b/Kukulcan/DeckEditorView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct DeckEditorView: View {
+    @Binding var deck: Deck
+    @EnvironmentObject var collection: CollectionStore
+    @State private var name: String
+    @State private var selection: Set<UUID>
+
+    init(deck: Binding<Deck>) {
+        _deck = deck
+        _name = State(initialValue: deck.wrappedValue.name)
+        _selection = State(initialValue: Set(deck.wrappedValue.cards.map { $0.id }))
+    }
+
+    var body: some View {
+        Form {
+            Section("Nom") {
+                TextField("Nom du deck", text: $name)
+            }
+            Section("Cartes (\(selection.count)/10)") {
+                ForEach(collection.ownedPlayable) { card in
+                    Button {
+                        if selection.contains(card.id) {
+                            selection.remove(card.id)
+                        } else if selection.count < 10 {
+                            selection.insert(card.id)
+                        }
+                    } label: {
+                        HStack {
+                            Text(card.name)
+                            Spacer()
+                            if selection.contains(card.id) {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                    .disabled(!selection.contains(card.id) && selection.count >= 10)
+                }
+            }
+        }
+        .navigationTitle("Deck")
+        .toolbar {
+            Button("Enregistrer") {
+                deck.name = name
+                deck.cards = collection.ownedPlayable.filter { selection.contains($0.id) }
+            }
+        }
+    }
+}
+

--- a/Kukulcan/DeckSelectionView.swift
+++ b/Kukulcan/DeckSelectionView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct DeckSelectionView: View {
+    @EnvironmentObject var collection: CollectionStore
+    @State private var selected: Deck?
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(collection.decks) { deck in
+                    Button {
+                        selected = deck
+                    } label: {
+                        HStack {
+                            Text(deck.name)
+                            Spacer()
+                            Text("\(deck.cards.count)/10")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .disabled(deck.cards.count != 10)
+                }
+            }
+            .navigationTitle("Choisir un deck")
+            .navigationDestination(item: $selected) { deck in
+                CombatView(
+                    engine: GameEngine(
+                        p1: PlayerState(name: "Toi", deck: deck.cards),
+                        p2: PlayerState(name: "IA", deck: StarterFactory.randomDeck())
+                    )
+                )
+            }
+        }
+    }
+}
+

--- a/Kukulcan/DecksView.swift
+++ b/Kukulcan/DecksView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct DecksView: View {
+    @EnvironmentObject var collection: CollectionStore
+
+    var body: some View {
+        List {
+            ForEach(collection.decks.indices, id: \.self) { i in
+                NavigationLink(destination: DeckEditorView(deck: $collection.decks[i])) {
+                    HStack {
+                        Text(collection.decks[i].name)
+                        Spacer()
+                        Text("\(collection.decks[i].cards.count)/10")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .onDelete { offsets in
+                collection.decks.remove(atOffsets: offsets)
+            }
+
+            if collection.decks.count < 20 {
+                Button {
+                    collection.decks.append(Deck(name: "Nouveau deck", cards: []))
+                } label: {
+                    Label("Créer un deck", systemImage: "plus")
+                }
+            }
+        }
+        .navigationTitle("Decks")
+        .toolbar { EditButton() }
+    }
+}
+

--- a/Kukulcan/MainTabView.swift
+++ b/Kukulcan/MainTabView.swift
@@ -11,16 +11,11 @@ struct MainTabView: View {
             CollectionView()
                 .tabItem { Label("Collection", systemImage: "square.grid.2x2.fill") }
 
-            if collection.ownedPlayable.count >= 10 {
-                CombatView(
-                    engine: GameEngine(
-                        p1: PlayerState(name: "Toi", deck: collection.ownedPlayable),
-                        p2: PlayerState(name: "IA", deck: StarterFactory.randomDeck())
-                    )
-                )
-                .tabItem { Label("Combats", systemImage: "gamecontroller.fill") }
+            if collection.decks.contains(where: { $0.cards.count == 10 }) {
+                DeckSelectionView()
+                    .tabItem { Label("Combats", systemImage: "gamecontroller.fill") }
             } else {
-                Text("Tu as besoin d'au moins 10 cartes pour combattre.")
+                Text("Crée un deck de 10 cartes pour combattre.")
                     .padding()
                     .tabItem { Label("Combats", systemImage: "gamecontroller.fill") }
             }


### PR DESCRIPTION
## Summary
- add deck model and persistence in collection store
- enable deck management and editing through collection view
- let players pick a 10-card deck before starting combat

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68ad2ac62c9c832b9f45eedb66cf8e7e