### PR TITLE
Unifie le dos des cartes et affine les bandeaux du détail

### DIFF
--- a/Kukulcan/CardView.swift
+++ b/Kukulcan/CardView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct CardBackView: View {
     /// Largeur de la carte. Utilisée pour calculer la hauteur du dos.
     var width: CGFloat = 140
+    /// Rayon des coins pour adapter l'arrondi selon le format d'affichage.
+    var cornerRadius: CGFloat = 18
     private let ratio: CGFloat = 1.5
 
     var body: some View {
@@ -13,7 +15,7 @@ struct CardBackView: View {
             .scaledToFill()
             .frame(width: width, height: h)
             .clipped()
-            .cornerRadius(18)
+            .cornerRadius(cornerRadius)
     }
 }
 


### PR DESCRIPTION
## Résumé
- Utilise le `LaunchLogo` pour le dos des cartes et rend le rayon des coins paramétrable.
- Revoit l'affichage détaillé d'une carte avec un dos couvrant toute la surface et sans symbole.
- Réduit de moitié les hauteurs des bandeaux haut et bas dans la vue détaillée.

## Tests
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68ad2f89df2c832b85d2605e1240914a