### PR TITLE
Use MayaRiver image on card backs

### DIFF
--- a/Kukulcan/CardView.swift
+++ b/Kukulcan/CardView.swift
@@ -8,7 +8,8 @@ struct CardBackView: View {
     var body: some View {
         let h = width * ratio
 
-        Image("LaunchLogo")
+        // Utilise l'image "MayaRiver" comme dos de carte
+        Image("MayaRiver")
             .resizable()
             .scaledToFill()
             .frame(width: width, height: h)


### PR DESCRIPTION
## Summary
- show the MayaRiver asset on the back of all cards

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ad3015b254832b8197e8b2a583dbb4