### PR TITLE
Adjust collection duplicate badge position

### DIFF
--- a/Kukulcan/CollectionView.swift
+++ b/Kukulcan/CollectionView.swift
@@ -60,7 +60,11 @@ struct CollectionView: View {
                                     selectedCard = card
                                 }
                                 .overlay(alignment: .topTrailing) {
-                                    if count > 1 { QuantityBadge(count: count).padding(6) }
+                                    if count > 1 {
+                                        QuantityBadge(count: count)
+                                            .padding(.trailing, 6)
+                                            .padding(.top, 32)
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- move duplicate quantity badge lower so it no longer overlaps card stats

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68adae5dfbf0832b828c0812cc6891b4