### PR TITLE
feat: add AI difficulty selection with rewards

### DIFF
--- a/Kukulcan/CombatView.swift
+++ b/Kukulcan/CombatView.swift
@@ -4,8 +4,13 @@ import UIKit
 struct CombatView: View {
     // Fournis un engine depuis l’extérieur si tu veux (collection/IA), sinon starter par défaut
     @StateObject private var engine: GameEngine
+    private let aiLevel: Int
+    var onWin: ((Int) -> Void)? = nil
+    @Environment(\.dismiss) private var dismiss
 
-    init(engine: GameEngine? = nil) {
+    init(engine: GameEngine? = nil, aiLevel: Int = 1, onWin: ((Int) -> Void)? = nil) {
+        self.aiLevel = aiLevel
+        self.onWin = onWin
         if let e = engine {
             _engine = StateObject(wrappedValue: e)
         } else {
@@ -124,6 +129,17 @@ struct CombatView: View {
         }
         .fullScreenCover(item: $selectedCard) { card in
             CardDetailView(card: card) { selectedCard = nil }
+        }
+        .onChange(of: engine.p1.hp) { hp in
+            if hp <= 0 {
+                dismiss()
+            }
+        }
+        .onChange(of: engine.p2.hp) { hp in
+            if hp <= 0 {
+                onWin?(aiLevel)
+                dismiss()
+            }
         }
     }
 
@@ -398,7 +414,7 @@ struct CombatView: View {
                 }
                 Button {
                     engine.endTurn()
-                    engine.performEasyAITurn()
+                    engine.performAITurn(level: aiLevel)
                 } label: {
                     Label("Fin du tour", systemImage: "arrow.uturn.right.circle.fill")
                 }

--- a/Kukulcan/DeckSelectionView.swift
+++ b/Kukulcan/DeckSelectionView.swift
@@ -2,35 +2,88 @@ import SwiftUI
 
 struct DeckSelectionView: View {
     @EnvironmentObject var collection: CollectionStore
-    @State private var selected: Deck?
+    @State private var selectedDeck: Deck? = nil
+    @State private var selectedLevel: Int? = nil
+    @State private var startCombat = false
+
+    @AppStorage("max_ai_level") private var maxAIUnlocked = 1
+    @AppStorage("ai_levels_won_mask") private var aiLevelsWonMask: Int = 0
+
+    private let levelRewards = Array(CardsDB.gods.prefix(5))
 
     var body: some View {
         NavigationStack {
-            List {
-                ForEach(collection.decks) { deck in
-                    Button {
-                        selected = deck
-                    } label: {
-                        HStack {
-                            Text(deck.name)
-                            Spacer()
-                            Text("\(deck.cards.count)/10")
-                                .foregroundStyle(.secondary)
+            VStack {
+                List {
+                    Section("Niveau IA") {
+                        ForEach(1...5, id: \.self) { lvl in
+                            let reward = levelRewards[lvl - 1]
+                            Button {
+                                selectedLevel = lvl
+                            } label: {
+                                HStack {
+                                    Text("Niveau \(lvl)")
+                                    Spacer()
+                                    CardView(card: reward, faceUp: true, width: 50)
+                                        .opacity(levelWon(lvl) ? 0.3 : 1)
+                                }
+                            }
+                            .disabled(lvl > maxAIUnlocked)
+                            .listRowBackground(selectedLevel == lvl ? Color.blue.opacity(0.2) : nil)
                         }
                     }
-                    .disabled(deck.cards.count != 10)
+                    Section("Decks") {
+                        ForEach(collection.decks) { deck in
+                            Button {
+                                selectedDeck = deck
+                            } label: {
+                                HStack {
+                                    Text(deck.name)
+                                    Spacer()
+                                    Text("\(deck.cards.count)/10")
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .disabled(deck.cards.count != 10)
+                            .listRowBackground(selectedDeck?.id == deck.id ? Color.blue.opacity(0.2) : nil)
+                        }
+                    }
                 }
+                Button("Débuter combat") {
+                    startCombat = true
+                }
+                .disabled(selectedDeck == nil || selectedLevel == nil)
+                .padding()
             }
             .navigationTitle("Choisir un deck")
-            .navigationDestination(item: $selected) { deck in
-                CombatView(
-                    engine: GameEngine(
-                        p1: PlayerState(name: "Toi", deck: deck.cards),
-                        p2: PlayerState(name: "IA", deck: StarterFactory.randomDeck())
+            .navigationDestination(isPresented: $startCombat) {
+                if let deck = selectedDeck, let lvl = selectedLevel {
+                    CombatView(
+                        engine: GameEngine(
+                            p1: PlayerState(name: "Toi", deck: deck.cards),
+                            p2: PlayerState(name: "IA", deck: StarterFactory.randomDeck())
+                        ),
+                        aiLevel: lvl,
+                        onWin: { handleWin(level: $0) }
                     )
-                )
+                }
             }
         }
     }
-}
 
+    private func levelWon(_ level: Int) -> Bool {
+        (aiLevelsWonMask & (1 << (level - 1))) != 0
+    }
+
+    private func handleWin(level: Int) {
+        let mask = 1 << (level - 1)
+        if aiLevelsWonMask & mask == 0 {
+            aiLevelsWonMask |= mask
+            if maxAIUnlocked < 5 && level == maxAIUnlocked {
+                maxAIUnlocked = level + 1
+            }
+            let reward = levelRewards[level - 1]
+            collection.add([reward])
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add deck screen AI level buttons with unlockable rewards
- invoke appropriate AI behavior per level
- track victories to grant god card rewards

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68ade554186c832b804de9d0b0cd2319