### PR TITLE
Align detail card colors and update rare styling

### DIFF
--- a/Kukulcan/CardDetailView.swift
+++ b/Kukulcan/CardDetailView.swift
@@ -44,12 +44,17 @@ struct CardDetailView: View {
 
                     let front = ZStack {
                         RoundedRectangle(cornerRadius: corner)
-                            .fill(.ultraThinMaterial)
+                            .fill(cardBackground)
                             .overlay(
                                 RoundedRectangle(cornerRadius: corner)
-                                    .stroke(card.rarity.glow.opacity(0.9), lineWidth: 2)
+                                    .stroke(glowStroke, lineWidth: borderWidth)
                             )
-                            .shadow(color: card.rarity.glow.opacity(0.6), radius: 14, x: 0, y: 10)
+                            .shadow(
+                                color: glowColor.opacity(haloOpacity),
+                                radius: haloRadius,
+                                x: 0,
+                                y: haloYOffset
+                            )
 
                         VStack(spacing: 0) {
                             // Bandeau haut
@@ -199,6 +204,51 @@ struct CardDetailView: View {
         }
         .padding(.horizontal, 12)
     }
+
+    // MARK: - Styles
+    private var cardBackground: LinearGradient {
+        if card.rarity == .legendary {
+            return LinearGradient(
+                colors: [
+                    glowColor,
+                    glowColor.opacity(0.8)
+                ],
+                startPoint: .topLeading, endPoint: .bottomTrailing
+            )
+        }
+        return LinearGradient(
+            colors: [
+                glowColor.opacity(0.15),
+                .black.opacity(0.85)
+            ],
+            startPoint: .topLeading, endPoint: .bottomTrailing
+        )
+    }
+
+    private var glowStroke: LinearGradient {
+        if card.rarity == .legendary {
+            return LinearGradient(
+                colors: [
+                    glowColor,
+                    glowColor.opacity(0.5)
+                ],
+                startPoint: .topLeading, endPoint: .bottomTrailing
+            )
+        }
+        return LinearGradient(
+            colors: [
+                glowColor.opacity(0.9),
+                glowColor.opacity(0.3)
+            ],
+            startPoint: .topLeading, endPoint: .bottomTrailing
+        )
+    }
+
+    private var borderWidth: CGFloat { card.rarity == .legendary ? 4 : 2 }
+    private var haloRadius: CGFloat { card.rarity == .legendary ? 20 : 10 }
+    private var haloYOffset: CGFloat { card.rarity == .legendary ? 10 : 6 }
+    private var haloOpacity: Double { card.rarity == .legendary ? 1.0 : 0.6 }
+    private var glowColor: Color { card.rarity == .legendary ? .orange : card.rarity.glow }
 
     private var typeChipBG: LinearGradient {
         switch card.type {

--- a/Kukulcan/Rarity.swift
+++ b/Kukulcan/Rarity.swift
@@ -13,7 +13,7 @@ extension Rarity {
     var colors: [Color] {
         switch self {
         case .common:     return [.gray.opacity(0.7), .gray.opacity(0.4)]
-        case .rare:       return [.blue, .teal]
+        case .rare:       return [.purple, .indigo]
         case .epic:       return [.purple, .pink]
         case .legendary:  return [.orange, .yellow]
         }
@@ -22,7 +22,7 @@ extension Rarity {
     var glow: Color {
         switch self {
         case .common:     return .gray.opacity(0.5)
-        case .rare:       return .blue.opacity(0.6)
+        case .rare:       return .purple.opacity(0.6)
         case .epic:       return .purple.opacity(0.6)
         case .legendary:  return .orange.opacity(0.8)
         }


### PR DESCRIPTION
## Summary
- Match card detail view background and glow with normal card appearance
- Give rare cards a purple gradient and matching glow

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ade5c02180832bb1ae00fd7a63454f