### PR TITLE
Refine combat mode layout

### DIFF
--- a/Kukulcan/CombatView.swift
+++ b/Kukulcan/CombatView.swift
@@ -112,14 +112,14 @@ struct CombatView: View {
         }
         .navigationTitle("Combats")
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar(.hidden, for: .tabBar)
         .safeAreaInset(edge: .bottom) {
             VStack(spacing: 8) {
                 footerControls
                 handStrip
             }
             .padding(.horizontal, 12)
-            // Ajout d’un padding supplémentaire pour dégager la barre de tabulation
-            .padding(.bottom, 64)
+            .padding(.bottom, 16)
             .background(.ultraThinMaterial)
         }
         .fullScreenCover(item: $selectedCard) { card in
@@ -153,6 +153,10 @@ struct CombatView: View {
     // MARK: - Opponent strip (aperçu board/dieu)
     private var opponentStrip: some View {
         VStack(spacing: 6) {
+            Text("Main adverse").font(.caption).foregroundStyle(.secondary)
+
+            opponentHandRow
+
             Text("Plateau adverse").font(.caption).foregroundStyle(.secondary)
 
             // Pioche adverse
@@ -184,6 +188,18 @@ struct CombatView: View {
                 }
             }
         }
+    }
+
+    private var opponentHandRow: some View {
+        ZStack {
+            ForEach(engine.opponent.hand.indices, id: \.self) { i in
+                CardBackView(width: 46)
+                    .rotation3DEffect(.degrees(15), axis: (x: 1, y: 0, z: 0))
+                    .rotationEffect(.degrees(Double(i - engine.opponent.hand.count/2) * 8))
+                    .offset(x: CGFloat(i - engine.opponent.hand.count/2) * 20)
+            }
+        }
+        .frame(height: 70)
     }
 
     // MARK: - Board du joueur
@@ -314,6 +330,7 @@ struct CombatView: View {
                             selectedCard = c
                         }
                         .matchedGeometryEffect(id: c.id, in: drawNamespace)
+                        .rotation3DEffect(.degrees(12), axis: (x: 1, y: 0, z: 0))
                         .opacity((animatingCard?.id == c.id || draggingCardIndex == idx) ? 0 : 1)
                         .gesture(
                             DragGesture(minimumDistance: 0, coordinateSpace: .named("combatArea"))


### PR DESCRIPTION
## Summary
- Hide the tab bar in combat and adjust bottom padding
- Display opponent hand with fanned card backs
- Add 3D rotation to player hand for depth effect

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68ade70d8624832b9838b8b4c68b4c2f