### PR TITLE
Preserve card identifiers during encoding

### DIFF
--- a/Kukulcan/Rules.swift
+++ b/Kukulcan/Rules.swift
@@ -24,7 +24,7 @@ enum RitualKind: String, Codable {
 
 /// Carte "statique" (modèle)
 struct Card: Identifiable, Codable, Hashable {
-    let id = UUID()
+    let id: UUID
     let name: String
     let type: CardType
     let rarity: Rarity
@@ -40,7 +40,8 @@ struct Card: Identifiable, Codable, Hashable {
     let effect: String    // texte synthétique à afficher sur la carte (footer)
     let lore: String?     // visible seulement en vue zoom
 
-    init(name: String,
+    init(id: UUID = UUID(),
+         name: String,
          type: CardType,
          rarity: Rarity,
          imageName: String,
@@ -50,6 +51,7 @@ struct Card: Identifiable, Codable, Hashable {
          bloodCost: Int = 0,
          effect: String,
          lore: String? = nil) {
+        self.id = id
         self.name = name
         self.type = type
         self.rarity = rarity
@@ -65,13 +67,14 @@ struct Card: Identifiable, Codable, Hashable {
 
 /// Instance vivante d’une carte sur le plateau (HP courant, etc.)
 struct CardInstance: Identifiable, Codable, Hashable {
-    let id = UUID()
+    let id: UUID
     let base: Card
     var currentHP: Int
 
-    init(_ card: Card) {
+    init(_ card: Card, id: UUID = UUID(), currentHP: Int? = nil) {
+        self.id = id
         self.base = card
-        self.currentHP = max(1, card.health)
+        self.currentHP = currentHP ?? max(1, card.health)
     }
 }
 

--- a/KukulcanTests/KukulcanTests.swift
+++ b/KukulcanTests/KukulcanTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Testing
+import Foundation
 @testable import Kukulcan
 
 struct KukulcanTests {
@@ -28,6 +29,25 @@ struct KukulcanTests {
         let engine = GameEngine(p1: p1, p2: p2)
         engine.playRitual(handIndex: 0, targetSlot: 0)
         #expect(engine.p1.discard.contains(where: { $0.id == ritual.id }))
+    }
+
+    /// `Card` should keep the same `id` after encoding and decoding.
+    @Test func cardIDIsStableThroughCoding() throws {
+        let card = Card(name: "Test", type: .common, rarity: .common,
+                        imageName: "test", attack: 1, health: 1, effect: "")
+        let data = try JSONEncoder().encode(card)
+        let decoded = try JSONDecoder().decode(Card.self, from: data)
+        #expect(card.id == decoded.id)
+    }
+
+    /// `CardInstance` should keep the same `id` after encoding and decoding.
+    @Test func cardInstanceIDIsStableThroughCoding() throws {
+        let card = Card(name: "Test", type: .common, rarity: .common,
+                        imageName: "test", attack: 1, health: 1, effect: "")
+        let inst = CardInstance(card)
+        let data = try JSONEncoder().encode(inst)
+        let decoded = try JSONDecoder().decode(CardInstance.self, from: data)
+        #expect(inst.id == decoded.id)
     }
 
 }


### PR DESCRIPTION
## Summary
- ensure `Card` and `CardInstance` keep their `id` when encoded and decoded
- add regression tests for `Card` and `CardInstance` coding stability

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68adf2fd18cc832bb2d3d87ed018abe3