### PR TITLE
feat: display life and blood in white

### DIFF
--- a/Kukulcan/CombatView.swift
+++ b/Kukulcan/CombatView.swift
@@ -163,7 +163,9 @@ struct CombatView: View {
                 HStack(spacing: 10) {
                     Label("\(engine.p1.hp)", systemImage: "heart.fill")
                     Label("\(engine.p1.blood)", systemImage: "drop.fill")
-                }.font(.subheadline)
+                }
+                .font(.subheadline)
+                .foregroundColor(.white)
             }
             Spacer()
             VStack(alignment: .trailing, spacing: 4) {
@@ -172,7 +174,9 @@ struct CombatView: View {
                 HStack(spacing: 10) {
                     Label("\(engine.p2.hp)", systemImage: "heart.fill")
                     Label("\(engine.p2.blood)", systemImage: "drop.fill")
-                }.font(.subheadline)
+                }
+                .font(.subheadline)
+                .foregroundColor(.white)
             }
         }
     }


### PR DESCRIPTION
## Summary
- use white color for health and blood labels so they show on dark background

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68adf66be8b4832b9bdffee1e38ff10e