### PR TITLE
Fix card drag positioning

### DIFF
--- a/Kukulcan/CombatView.swift
+++ b/Kukulcan/CombatView.swift
@@ -86,7 +86,6 @@ struct CombatView: View {
                 }
             }
         }
-        .coordinateSpace(name: "combatArea")
         .onAppear {
             // Démarrer la partie si pas déjà fait
             if engine.p1.hand.isEmpty && engine.p2.hand.isEmpty {
@@ -152,6 +151,7 @@ struct CombatView: View {
                 dismiss()
             }
         }
+        .coordinateSpace(name: "combatArea")
     }
 
     // MARK: - Header (scores / sang)
@@ -360,11 +360,10 @@ struct CombatView: View {
                     .gesture(
                         DragGesture(minimumDistance: 0, coordinateSpace: .named("combatArea"))
                             .onChanged { value in
-                                guard value.translation.height < 0 else { return }
+                                dragPosition = value.location
                                 if draggingCardIndex == nil {
                                     draggingCardIndex = idx
                                 }
-                                dragPosition = value.location
                                 if let slot = slotFrames.first(where: { $0.value.contains(value.location) })?.key {
                                     if hoveredSlot != slot {
                                         hoveredSlot = slot


### PR DESCRIPTION
## Summary
- allow card to follow finger during drag
- ensure drag coordinate space includes the hand area

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68adf6fcee38832b9054b250e642f3c3