### PR TITLE
Limit card copies per deck and move deck builder to combat

### DIFF
--- a/Kukulcan/CollectionView.swift
+++ b/Kukulcan/CollectionView.swift
@@ -74,13 +74,6 @@ struct CollectionView: View {
                 }
             }
             .navigationTitle("Collection")
-            .toolbar {
-                NavigationLink {
-                    DecksView()
-                } label: {
-                    Label("Decks", systemImage: "folder")
-                }
-            }
             // ⬇︎ Place le fond derrière tout le contenu de la stack
             .background(
                 CollectionBackground()

--- a/Kukulcan/Deck.swift
+++ b/Kukulcan/Deck.swift
@@ -4,5 +4,19 @@ struct Deck: Identifiable, Codable, Hashable {
     var id: UUID = UUID()
     var name: String
     var cards: [Card]
+
+    /// Validate deck composition according to game rules.
+    /// - Returns: `true` if the deck does not exceed copy limits.
+    /// A deck may contain up to three copies of the same card,
+    /// except for cards of type `.god` which are limited to one copy.
+    func isValid() -> Bool {
+        var counts: [String: Int] = [:]
+        for c in cards {
+            counts[c.name, default: 0] += 1
+            let limit = c.type == .god ? 1 : 3
+            if counts[c.name, default: 0] > limit { return false }
+        }
+        return true
+    }
 }
 

--- a/Kukulcan/DeckEditorView.swift
+++ b/Kukulcan/DeckEditorView.swift
@@ -20,9 +20,13 @@ struct DeckEditorView: View {
             Section("Cartes (\(selection.count)/10)") {
                 ForEach(collection.ownedPlayable) { card in
                     Button {
+                        let limit = card.type == .god ? 1 : 3
+                        let copies = collection.ownedPlayable.filter {
+                            $0.name == card.name && selection.contains($0.id)
+                        }.count
                         if selection.contains(card.id) {
                             selection.remove(card.id)
-                        } else if selection.count < 10 {
+                        } else if selection.count < 10 && copies < limit {
                             selection.insert(card.id)
                         }
                     } label: {
@@ -34,7 +38,13 @@ struct DeckEditorView: View {
                             }
                         }
                     }
-                    .disabled(!selection.contains(card.id) && selection.count >= 10)
+                    .disabled(
+                        !selection.contains(card.id) &&
+                        (selection.count >= 10 ||
+                         collection.ownedPlayable.filter {
+                            $0.name == card.name && selection.contains($0.id)
+                         }.count >= (card.type == .god ? 1 : 3))
+                    )
                 }
             }
         }

--- a/Kukulcan/DeckSelectionView.swift
+++ b/Kukulcan/DeckSelectionView.swift
@@ -56,6 +56,13 @@ struct DeckSelectionView: View {
                 .padding()
             }
             .navigationTitle("Choisir un deck")
+            .toolbar {
+                NavigationLink {
+                    DecksView()
+                } label: {
+                    Label("Decks", systemImage: "folder")
+                }
+            }
             .navigationDestination(isPresented: $startCombat) {
                 if let deck = selectedDeck, let lvl = selectedLevel {
                     CombatView(

--- a/KukulcanTests/KukulcanTests.swift
+++ b/KukulcanTests/KukulcanTests.swift
@@ -67,4 +67,24 @@ struct KukulcanTests {
         #expect(inst?.currentHP == 2)
     }
 
+    /// Decks should respect copy limits: max 3 per card, 1 for gods.
+    @Test func deckCopyLimits() {
+        let c1 = Card(name: "Soldat", type: .common, rarity: .common,
+                      imageName: "soldat", attack: 1, health: 1, effect: "")
+        let c2 = Card(name: "Soldat", type: .common, rarity: .common,
+                      imageName: "soldat", attack: 1, health: 1, effect: "")
+        let c3 = Card(name: "Soldat", type: .common, rarity: .common,
+                      imageName: "soldat", attack: 1, health: 1, effect: "")
+        let c4 = Card(name: "Soldat", type: .common, rarity: .common,
+                      imageName: "soldat", attack: 1, health: 1, effect: "")
+        let g1 = Card(name: "Kinich", type: .god, rarity: .legendary,
+                      imageName: "kinich", attack: 5, health: 5, bloodCost: 7, effect: "")
+        let g2 = Card(name: "Kinich", type: .god, rarity: .legendary,
+                      imageName: "kinich", attack: 5, health: 5, bloodCost: 7, effect: "")
+
+        #expect(Deck(name: "ok", cards: [c1, c2, c3]).isValid())
+        #expect(!Deck(name: "too many", cards: [c1, c2, c3, c4]).isValid())
+        #expect(!Deck(name: "gods", cards: [g1, g2]).isValid())
+        #expect(Deck(name: "one god", cards: [g1, c1]).isValid())
+    }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .target(
             name: "Kukulcan",
             path: "Kukulcan",
-            sources: ["Placeholder.swift", "Rules.swift"]
+            sources: ["Placeholder.swift", "Rules.swift", "Deck.swift"]
         ),
         .testTarget(
             name: "KukulcanTests",


### PR DESCRIPTION
## Summary
- Enforce deck composition limits: max 3 copies per card and 1 for gods
- Add validation helpers and tests for deck copy rules
- Relocate deck management to the combat tab

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68adf9b1169c832bb006d3bdc418709b