### PR TITLE
Add deck creation button in combat tab

### DIFF
--- a/Kukulcan/MainTabView.swift
+++ b/Kukulcan/MainTabView.swift
@@ -15,9 +15,20 @@ struct MainTabView: View {
                 DeckSelectionView()
                     .tabItem { Label("Combats", systemImage: "gamecontroller.fill") }
             } else {
-                Text("Crée un deck de 10 cartes pour combattre.")
+                NavigationStack {
+                    VStack(spacing: 16) {
+                        Text("Crée un deck de 10 cartes pour combattre.")
+                            .multilineTextAlignment(.center)
+                        NavigationLink {
+                            DecksView()
+                        } label: {
+                            Label("Créer un deck", systemImage: "plus")
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
                     .padding()
-                    .tabItem { Label("Combats", systemImage: "gamecontroller.fill") }
+                }
+                .tabItem { Label("Combats", systemImage: "gamecontroller.fill") }
             }
         }
         .tint(.orange)


### PR DESCRIPTION
## Summary
- Show a message and navigation link to create a deck when the combat tab is opened without a full deck

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68adff24e324832b8c9073d2285d91eb