### PR TITLE
Hide navigation bar on home screen

### DIFF
--- a/Kukulcan/PacksView.swift
+++ b/Kukulcan/PacksView.swift
@@ -87,11 +87,7 @@ struct PacksView: View {
                 }
                 .padding(.horizontal)
             }
-            .navigationTitle("Accueil")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar(.visible, for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
-            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .toolbar(.hidden, for: .navigationBar)
             .toolbar(.visible, for: .tabBar)
             .background(
                 PacksBackdrop(closeUp: showOpening, bloodProgress: bloodProgress).ignoresSafeArea()


### PR DESCRIPTION
## Summary
- hide top navigation bar on Accueil screen so title no longer appears

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68adff67605c832bb6e4d4a4b7e5497a