### PR TITLE
Reset ritual bonus after turn end

### DIFF
--- a/Kukulcan/Rules.swift
+++ b/Kukulcan/Rules.swift
@@ -330,8 +330,14 @@ final class GameEngine: ObservableObject {
     }
 
     func endTurn() {
-        // reset visuel slot sacrifice
-        if currentPlayerIsP1 { p1.sacrificeSlot = nil } else { p2.sacrificeSlot = nil }
+        // reset visuel slot sacrifice et bonus de sang
+        if currentPlayerIsP1 {
+            p1.sacrificeSlot = nil
+            p1.pendingBonusBlood = 0
+        } else {
+            p2.sacrificeSlot = nil
+            p2.pendingBonusBlood = 0
+        }
         currentPlayerIsP1.toggle()
         log.append("—— Tour terminé. À \(activeName()) de jouer.")
         // pioche automatique

--- a/KukulcanTests/KukulcanTests.swift
+++ b/KukulcanTests/KukulcanTests.swift
@@ -19,7 +19,7 @@ struct KukulcanTests {
     /// Vérifie que le rituel Couteau d'obsidienne est bien défaussé après utilisation.
     @Test func obsidianKnifeIsDiscarded() {
         var p1 = PlayerState(name: "P1")
-        var p2 = PlayerState(name: "P2")
+        let p2 = PlayerState(name: "P2")
         let ritual = Card(name: "Couteau d'obsidienne", type: .ritual, rarity: .rare,
                           imageName: "", ritual: .obsidianKnife, effect: "")
         let common = Card(name: "Soldat", type: .common, rarity: .common,
@@ -53,7 +53,7 @@ struct KukulcanTests {
     /// `Charme forestier` should grant +1 attack and +1 health to a targeted common.
     @Test func forestCharmBuffsStats() {
         var p1 = PlayerState(name: "P1")
-        var p2 = PlayerState(name: "P2")
+        let p2 = PlayerState(name: "P2")
         let ritual = Card(name: "Charme forestier", type: .ritual, rarity: .rare,
                           imageName: "", ritual: .forestCharm, effect: "")
         let common = Card(name: "Soldat", type: .common, rarity: .common,
@@ -65,6 +65,16 @@ struct KukulcanTests {
         let inst = engine.p1.board[0]
         #expect(inst?.currentAttack == 2)
         #expect(inst?.currentHP == 2)
+    }
+
+    /// `pendingBonusBlood` should reset to 0 at end of turn.
+    @Test func pendingBonusBloodResets() {
+        var p1 = PlayerState(name: "P1")
+        let p2 = PlayerState(name: "P2")
+        p1.pendingBonusBlood = 1
+        let engine = GameEngine(p1: p1, p2: p2)
+        engine.endTurn()
+        #expect(engine.p1.pendingBonusBlood == 0)
     }
 
     /// Decks should respect copy limits: max 3 per card, 1 for gods.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "92b00e1a82db24741e99d45376cc79ceea546dc1c7262e190a92e8e3ac2abb77",
+  "originHash" : "86371adfa2a628acbbafb658cc077a7d9c5cf38a68a103f20189bd0dab691491",
   "pins" : [
     {
       "identity" : "swift-syntax",


### PR DESCRIPTION
## Summary
- Clear pending blood bonus when a player's turn ends
- Update tests and add coverage for ritual bonus reset

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68adffe2d968832ba07356dd16da7fdf