### PR TITLE
feat: add rules reference and lock level messaging

### DIFF
--- a/Kukulcan/DeckSelectionView.swift
+++ b/Kukulcan/DeckSelectionView.swift
@@ -5,6 +5,7 @@ struct DeckSelectionView: View {
     @State private var selectedDeck: Deck? = nil
     @State private var selectedLevel: Int? = nil
     @State private var startCombat = false
+    @State private var showLockedAlert = false
 
     @AppStorage("max_ai_level") private var maxAIUnlocked = 1
     @AppStorage("ai_levels_won_mask") private var aiLevelsWonMask: Int = 0
@@ -18,8 +19,13 @@ struct DeckSelectionView: View {
                     Section("Niveau IA") {
                         ForEach(1...5, id: \.self) { lvl in
                             let reward = levelRewards[lvl - 1]
+                            let locked = lvl > maxAIUnlocked
                             Button {
-                                selectedLevel = lvl
+                                if locked {
+                                    showLockedAlert = true
+                                } else {
+                                    selectedLevel = lvl
+                                }
                             } label: {
                                 HStack {
                                     Text("Niveau \(lvl)")
@@ -27,8 +33,8 @@ struct DeckSelectionView: View {
                                     CardView(card: reward, faceUp: true, width: 50)
                                         .opacity(levelWon(lvl) ? 0.3 : 1)
                                 }
+                                .opacity(locked ? 0.5 : 1)
                             }
-                            .disabled(lvl > maxAIUnlocked)
                             .listRowBackground(selectedLevel == lvl ? Color.blue.opacity(0.2) : nil)
                         }
                     }
@@ -57,10 +63,17 @@ struct DeckSelectionView: View {
             }
             .navigationTitle("Choisir un deck")
             .toolbar {
-                NavigationLink {
-                    DecksView()
-                } label: {
-                    Label("Decks", systemImage: "folder")
+                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    NavigationLink {
+                        DecksView()
+                    } label: {
+                        Label("Decks", systemImage: "folder")
+                    }
+                    NavigationLink {
+                        RulesView()
+                    } label: {
+                        Label("Règles", systemImage: "questionmark.circle")
+                    }
                 }
             }
             .navigationDestination(isPresented: $startCombat) {
@@ -75,6 +88,9 @@ struct DeckSelectionView: View {
                     )
                 }
             }
+        }
+        .alert("Tu dois terminer le niveau précédent.", isPresented: $showLockedAlert) {
+            Button("OK", role: .cancel) {}
         }
     }
 

--- a/Kukulcan/RulesView.swift
+++ b/Kukulcan/RulesView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct RulesView: View {
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Règles du jeu")
+                    .font(.title)
+                Text("""
+Kukulcan est un jeu de cartes tactique. Chaque joueur commence avec 10 points de vie.
+Pose des cartes communes pour attaquer, sacrifie-les pour gagner du sang et invoquer des dieux puissants.
+Le premier à réduire les points de vie de l'adversaire à zéro remporte la partie.
+""")
+            }
+            .padding()
+        }
+        .navigationTitle("Règles")
+    }
+}
+
+#Preview {
+    RulesView()
+}


### PR DESCRIPTION
## Summary
- add `RulesView` and button to open it from deck selection
- grey out locked AI levels and show alert when tapped

## Testing
- `swift build`


------
https://chatgpt.com/codex/tasks/task_e_68ae08ed863c832b8d0cc418745768bc