### PR TITLE
Remove extraneous frame modifier from CombatView initializer

### DIFF
--- a/Kukulcan/CombatView.swift
+++ b/Kukulcan/CombatView.swift
@@ -19,7 +19,6 @@ struct CombatView: View {
             let p2 = PlayerState(name: "IA",  deck: StarterFactory.randomDeck())
             _engine = StateObject(wrappedValue: GameEngine(p1: p1, p2: p2))
         }
-        .frame(maxWidth: .infinity)
     }
 
     // Sélections légères pour actions


### PR DESCRIPTION
## Summary
- drop misplaced `.frame(maxWidth: .infinity)` from `CombatView` init to resolve compilation error

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0e2cb840832bb7ee07dfe882794d