### PR TITLE
Fix presentation detent compile error

### DIFF
--- a/Kukulcan/CombatView.swift
+++ b/Kukulcan/CombatView.swift
@@ -111,11 +111,13 @@ struct CombatView: View {
         }
         .sheet(isPresented: $showTargetPickerForRitual) {
             ritualTargetSheet
-                .presentationDetents([.height(280)])
+                // Use a fraction-based detent to avoid requiring iOS 17's height API
+                .presentationDetents([.fraction(0.35)])
         }
         .sheet(isPresented: $showAttackPicker) {
             attackTargetSheet
-                .presentationDetents([.height(320)])
+                // Same workaround here – approximate desired height with a fraction
+                .presentationDetents([.fraction(0.45)])
         }
         .navigationTitle("Combats")
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
## Summary
- avoid `.height` detents in `CombatView` by using fraction-based detents

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1140999c832b8cdec9c121f31486