### PR TITLE
Ajuster la disposition du combat sur mobile

### DIFF
--- a/Kukulcan/CombatView.swift
+++ b/Kukulcan/CombatView.swift
@@ -42,10 +42,12 @@ struct CombatView: View {
     @State private var slotFrames: [Int: CGRect] = [:]
 
     // Tailles réduites pour mieux voir l’ensemble du plateau
-    private let slotCardWidth: CGFloat = 72
-    private let slotCardHeight: CGFloat = 100
-    private let deckCardWidth: CGFloat = 46
-    private let deckCardHeight: CGFloat = 64
+    private let slotCardWidth: CGFloat = 60
+    private let slotCardHeight: CGFloat = 84
+    private let deckCardWidth: CGFloat = 40
+    private let deckCardHeight: CGFloat = 56
+    private let handCardWidth: CGFloat = 90
+    private var handCardHeight: CGFloat { handCardWidth * 1.4 }
 
     var body: some View {
         GeometryReader { _ in
@@ -71,6 +73,7 @@ struct CombatView: View {
                 }
                 .padding(.horizontal, 12)
                 .padding(.top, 8)
+                .padding(.bottom, handCardHeight + 20)
 
                 if showBloodRiver {
                     BloodRiverView()
@@ -79,7 +82,7 @@ struct CombatView: View {
                 }
 
                 if let idx = draggingCardIndex {
-                    CardView(card: engine.current.hand[idx], faceUp: true, width: 120)
+                    CardView(card: engine.current.hand[idx], faceUp: true, width: handCardWidth)
                         .position(dragPosition)
                         .shadow(radius: 8)
                         .zIndex(1)
@@ -195,9 +198,9 @@ struct CombatView: View {
                 Text("Pioche :").font(.caption)
                 ZStack {
                     if engine.opponent.deck.isEmpty {
-                        emptySlot(width: 46, height: 64)
+                        emptySlot(width: deckCardWidth, height: deckCardHeight)
                     } else {
-                        CardBackView().frame(width: 46, height: 64)
+                        CardBackView().frame(width: deckCardWidth, height: deckCardHeight)
                         Text("\(engine.opponent.deck.count)")
                             .font(.caption.bold())
                             .foregroundStyle(.white)
@@ -224,7 +227,7 @@ struct CombatView: View {
     private var opponentHandRow: some View {
         ZStack {
             ForEach(engine.opponent.hand.indices, id: \.self) { i in
-                CardBackView(width: 46)
+                CardBackView(width: deckCardWidth)
                     .rotation3DEffect(.degrees(15), axis: (x: 1, y: 0, z: 0))
                     .rotationEffect(.degrees(Double(i - engine.opponent.hand.count/2) * 8))
                     .offset(x: CGFloat(i - engine.opponent.hand.count/2) * 20)
@@ -274,6 +277,7 @@ struct CombatView: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Zones spéciales (Dieu / Sacrifice / Défausse)
@@ -347,6 +351,7 @@ struct CombatView: View {
             }
             Spacer()
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     // MARK: - Main du joueur
@@ -355,7 +360,7 @@ struct CombatView: View {
             HStack(spacing: 10) {
                 ForEach(engine.current.hand.indices, id: \.self) { idx in
                     let c = engine.current.hand[idx]
-                    CardView(card: c, faceUp: true, width: 120) {
+                    CardView(card: c, faceUp: true, width: handCardWidth) {
                         selectedCard = c
                     }
                     .matchedGeometryEffect(id: c.id, in: drawNamespace)


### PR DESCRIPTION
## Summary
- Réduire la taille des cartes du deck et de la main
- Aligner le plateau et les zones spéciales sur la gauche et ajouter un espacement inférieur pour éviter le chevauchement

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ae1901ea18832ba39272bbae52e5c3