### PR TITLE
Remove duplicate collection button on home screen

### DIFF
--- a/Kukulcan/PacksView.swift
+++ b/Kukulcan/PacksView.swift
@@ -74,18 +74,10 @@ struct PacksView: View {
 
                 Spacer()
 
-                HStack {
-                    Text("Cartes possédées : \(collection.owned.count)")
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.85)
-                    Spacer()
-                    NavigationLink {
-                        CollectionView()
-                    } label: {
-                        Label("Voir la collection", systemImage: "square.grid.2x2")
-                    }
-                }
-                .padding(.horizontal)
+                Text("Cartes possédées : \(collection.owned.count)")
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+                    .padding(.horizontal)
             }
             .toolbar(.hidden, for: .navigationBar)
             .toolbar(.visible, for: .tabBar)


### PR DESCRIPTION
## Summary
- remove redundant "Voir la collection" navigation link from home packs screen

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ae2f903a44832b923904ad97dd5aaf