### PR TITLE
Add background music for key sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Carthage/Build/
 # Secrets/API keys
 **/Secrets*.swift
 *.env
+
+# Audio assets
+*.wav

--- a/Kukulcan/AudioManager.swift
+++ b/Kukulcan/AudioManager.swift
@@ -1,0 +1,32 @@
+import Foundation
+import AVFoundation
+
+final class AudioManager {
+    static let shared = AudioManager()
+    private var player: AVAudioPlayer?
+
+    enum Track: String {
+        case home
+        case collection
+        case combat
+    }
+
+    func play(_ track: Track) {
+        guard let url = Bundle.main.url(forResource: track.rawValue, withExtension: "wav") else {
+            print("Missing sound file: \(track.rawValue).wav")
+            return
+        }
+        do {
+            player = try AVAudioPlayer(contentsOf: url)
+            player?.numberOfLoops = -1
+            player?.play()
+        } catch {
+            print("Audio playback failed: \(error)")
+        }
+    }
+
+    func stop() {
+        player?.stop()
+        player = nil
+    }
+}

--- a/Kukulcan/CollectionView.swift
+++ b/Kukulcan/CollectionView.swift
@@ -83,6 +83,8 @@ struct CollectionView: View {
         .fullScreenCover(item: $selectedCard) { card in
             CardDetailView(card: card) { selectedCard = nil }
         }
+        .onAppear { AudioManager.shared.play(.collection) }
+        .onDisappear { AudioManager.shared.stop() }
     }
 
 

--- a/Kukulcan/CombatView.swift
+++ b/Kukulcan/CombatView.swift
@@ -94,6 +94,10 @@ struct CombatView: View {
             if engine.p1.hand.isEmpty && engine.p2.hand.isEmpty {
                 engine.start()
             }
+            AudioManager.shared.play(.combat)
+        }
+        .onDisappear {
+            AudioManager.shared.stop()
         }
         .onChange(of: engine.lastDrawnCard) { card in
             guard let card else { return }

--- a/Kukulcan/PacksView.swift
+++ b/Kukulcan/PacksView.swift
@@ -106,6 +106,8 @@ struct PacksView: View {
         .fullScreenCover(item: $selectedCard) { card in
             CardDetailView(card: card) { selectedCard = nil }
         }
+        .onAppear { AudioManager.shared.play(.home) }
+        .onDisappear { AudioManager.shared.stop() }
     }
 }
 


### PR DESCRIPTION
## Summary
- add simple audio manager to loop background tracks
- play distinct soundtrack on home, collection, and combat screens
- remove bundled WAV files and ignore audio assets to keep repo lean

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ae2f585db8832bac356dfd576e5d55