### PR TITLE
Fix welcome music and tab audio conflicts

### DIFF
--- a/Kukulcan/AudioManager.swift
+++ b/Kukulcan/AudioManager.swift
@@ -12,6 +12,8 @@ final class AudioManager {
     }
 
     func play(_ track: Track, volume: Float = 0.25) {
+        // Arrête toute piste en cours avant d'en jouer une nouvelle
+        stop()
         guard let url = Bundle.main.url(forResource: track.rawValue, withExtension: "mp3") else {
             print("Missing sound file: \(track.rawValue).mp3")
             return

--- a/Kukulcan/CollectionView.swift
+++ b/Kukulcan/CollectionView.swift
@@ -84,7 +84,6 @@ struct CollectionView: View {
             CardDetailView(card: card) { selectedCard = nil }
         }
         .onAppear { AudioManager.shared.play(.collection) }
-        .onDisappear { AudioManager.shared.stop() }
     }
 
 

--- a/Kukulcan/CombatView.swift
+++ b/Kukulcan/CombatView.swift
@@ -96,9 +96,6 @@ struct CombatView: View {
             }
             AudioManager.shared.play(.combat)
         }
-        .onDisappear {
-            AudioManager.shared.stop()
-        }
         .onChange(of: engine.lastDrawnCard) { card in
             guard let card else { return }
             animatingCard = card

--- a/Kukulcan/ElementClashApp.swift
+++ b/Kukulcan/ElementClashApp.swift
@@ -8,19 +8,18 @@ struct ElementClashApp: App {
     var body: some Scene {
         WindowGroup {
             ZStack {
-                MainTabView()
-                    .environmentObject(collection)
-                    .opacity(showSplash ? 0 : 1)
-                    .transition(.opacity)
-
                 if showSplash {
-                    // Si tu utilises l’intro “MayaBloodSplashView”
+                    // Écran d’introduction sans musique
                     MayaBloodSplashView {
                         withAnimation(.easeInOut(duration: 0.35)) {
                             showSplash = false
                         }
                     }
                     .transition(.opacity)
+                } else {
+                    MainTabView()
+                        .environmentObject(collection)
+                        .transition(.opacity)
                 }
             }
         }

--- a/Kukulcan/PacksView.swift
+++ b/Kukulcan/PacksView.swift
@@ -99,7 +99,6 @@ struct PacksView: View {
             CardDetailView(card: card) { selectedCard = nil }
         }
         .onAppear { AudioManager.shared.play(.home) }
-        .onDisappear { AudioManager.shared.stop() }
     }
 }
 


### PR DESCRIPTION
## Summary
- Show main tabs only after splash to avoid early home music
- Remove per-view audio stops and centralize stop in AudioManager
- Prevent audio race when switching tabs

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ae3ed2c898832ba85467f9a46ebc1c