### PR TITLE
Ajoute achat de packs avec l'or du joueur

### DIFF
--- a/Kukulcan/CollectionStore.swift
+++ b/Kukulcan/CollectionStore.swift
@@ -17,12 +17,28 @@ final class CollectionStore: ObservableObject {
         didSet { saveDecks() }
     }
 
+    // Monnaie du joueur
+    @AppStorage("player_gold_v1") var gold: Int = 0
+
     init() {
         load()
         loadDecks()
     }
 
     // MARK: - Packs
+
+    /// Dépense de l'or du joueur
+    func spendGold(_ amount: Int) {
+        gold = max(gold - amount, 0)
+    }
+
+    /// Achète et ouvre un pack si assez d'or
+    @discardableResult
+    func buyPack(cost: Int) -> [Card]? {
+        guard gold >= cost else { return nil }
+        spendGold(cost)
+        return openPack()
+    }
 
     /// Ouvre un pack (mélange commune/rituel/dieu selon `CardsDB.mixedPack`)
     /// et ajoute les cartes tirées à la collection.

--- a/Kukulcan/PacksView.swift
+++ b/Kukulcan/PacksView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct PacksView: View {
     @EnvironmentObject var collection: CollectionStore
+    private let packCost = 100
 
     @State private var lastPulled: [Card] = []
     @State private var showOpening = false
@@ -38,10 +39,21 @@ struct PacksView: View {
                 }
                 .padding(.horizontal)
 
+                // Affichage de l'or et du coût
+                HStack {
+                    Text("Or : \(collection.gold)")
+                    Spacer()
+                    Text("Coût : \(packCost)")
+                }
+                .padding(.horizontal)
+
                 // Bouton ouvrir
                 Button {
-                    lastPulled = collection.openPack()   // ⬅️ remplace drawMixedPack()
-                    showOpening = true
+                    if collection.gold >= packCost {
+                        collection.spendGold(packCost)
+                        lastPulled = collection.openPack()
+                        showOpening = true
+                    }
                 } label: {
                     Label("Ouvrir un pack", systemImage: "sparkles")
                         .font(.headline)
@@ -50,6 +62,7 @@ struct PacksView: View {
                         .foregroundStyle(.white)
                         .shadow(radius: 6)
                 }
+                .disabled(collection.gold < packCost)
 
                 // Aperçu des cartes tirées
                 if !lastPulled.isEmpty {


### PR DESCRIPTION
## Summary
- Ajout d'une monnaie `gold` et de méthodes pour la dépenser ou acheter un pack
- Affiche l'or disponible et le coût d'un pack
- Le bouton d'ouverture dépense l'or et se désactive si la somme est insuffisante

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ae605189c4832b936fbf6edd732ffc