### PR TITLE
Add gold rewards for AI victories

### DIFF
--- a/Kukulcan/CollectionStore.swift
+++ b/Kukulcan/CollectionStore.swift
@@ -6,6 +6,7 @@ final class CollectionStore: ObservableObject {
     // Persistance locale
     @AppStorage("owned_cards_v2") private var ownedData: Data = Data()
     @AppStorage("player_decks_v1") private var decksData: Data = Data()
+    @AppStorage("player_gold_v1") private var goldData: Int = 0
 
     // Cartes possédées
     @Published var owned: [Card] = [] {
@@ -17,9 +18,15 @@ final class CollectionStore: ObservableObject {
         didSet { saveDecks() }
     }
 
+    // Or du joueur
+    @Published var gold: Int = 0 {
+        didSet { goldData = gold }
+    }
+
     init() {
         load()
         loadDecks()
+        gold = goldData
     }
 
     // MARK: - Packs
@@ -54,6 +61,11 @@ final class CollectionStore: ObservableObject {
     /// Ajoute manuellement des cartes à la collection
     func add(_ cards: [Card]) {
         owned.append(contentsOf: cards)
+    }
+
+    /// Ajoute de l'or à la collection
+    func addGold(_ amount: Int) {
+        gold += amount
     }
 
     // MARK: - Helpers d’affichage
@@ -121,6 +133,7 @@ final class CollectionStore: ObservableObject {
     func resetCollection() {
         owned.removeAll()
         decks.removeAll()
+        gold = 0
     }
 }
 

--- a/Kukulcan/DeckSelectionView.swift
+++ b/Kukulcan/DeckSelectionView.swift
@@ -6,6 +6,8 @@ struct DeckSelectionView: View {
     @State private var selectedLevel: Int? = nil
     @State private var startCombat = false
     @State private var showLockedAlert = false
+    @State private var showGoldAlert = false
+    @State private var lastGoldReward = 0
 
     @AppStorage("max_ai_level") private var maxAIUnlocked = 1
     @AppStorage("ai_levels_won_mask") private var aiLevelsWonMask: Int = 0
@@ -89,6 +91,11 @@ struct DeckSelectionView: View {
                 }
             }
         }
+        .alert("Récompense", isPresented: $showGoldAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Tu reçois \(lastGoldReward) or")
+        }
         .alert("Tu dois terminer le niveau précédent.", isPresented: $showLockedAlert) {
             Button("OK", role: .cancel) {}
         }
@@ -107,6 +114,10 @@ struct DeckSelectionView: View {
             }
             let reward = levelRewards[level - 1]
             collection.add([reward])
+            let goldReward = 50 * level
+            collection.addGold(goldReward)
+            lastGoldReward = goldReward
+            showGoldAlert = true
         }
     }
 }


### PR DESCRIPTION
## Summary
- Track player gold in `CollectionStore` with persistent storage and helper to add gold
- Award gold when winning AI levels and show alert with amount earned

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ae60544170832bbd4dee6a0316b598