### PR TITLE
Add gold economy persistence tests

### DIFF
--- a/KukulcanTests/KukulcanTests.swift
+++ b/KukulcanTests/KukulcanTests.swift
@@ -123,4 +123,41 @@ struct KukulcanTests {
         #expect(!Deck(name: "gods", cards: [g1, g2]).isValid())
         #expect(Deck(name: "one god", cards: [g1, c1]).isValid())
     }
+
+    /// Gold should persist across instances, spending should reduce it and buying packs should fail if insufficient.
+    @Test func testGoldSpendingAndSaving() {
+        var store = CollectionStore()
+        store.resetCollection() // clean state
+
+        // Add and spend gold
+        store.addGold(200)
+        #expect(store.spendGold(150))
+        #expect(store.gold == 50)
+
+        // Gold should persist after reloading
+        var reloaded = CollectionStore()
+        #expect(reloaded.gold == 50)
+
+        // Cannot buy pack without enough gold
+        let attempt = reloaded.buyPack(cost: 100)
+        #expect(attempt == nil)
+        #expect(reloaded.owned.isEmpty)
+        #expect(reloaded.gold == 50)
+
+        // Add enough gold and buy a pack
+        reloaded.addGold(100)
+        let pack = reloaded.buyPack(cost: 100)
+        #expect(pack?.count == 3)
+        #expect(reloaded.gold == 50)
+
+        // Reset should clear gold and collection
+        reloaded.resetCollection()
+        #expect(reloaded.gold == 0)
+        #expect(reloaded.owned.isEmpty)
+
+        // Reloaded instance after reset should also have zero gold
+        let fresh = CollectionStore()
+        #expect(fresh.gold == 0)
+        #expect(fresh.owned.isEmpty)
+    }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .target(
             name: "Kukulcan",
             path: "Kukulcan",
-            sources: ["Rules.swift", "Deck.swift"]
+            sources: ["Rules.swift", "Deck.swift", "CollectionStore.swift", "CardsDatabase.swift"]
         ),
         .testTarget(
             name: "KukulcanTests",


### PR DESCRIPTION
## Summary
- persist player gold in `CollectionStore` with spend and pack purchase helpers
- expose CollectionStore and card database to SwiftPM target
- add `testGoldSpendingAndSaving` to cover gold spending, pack buying, and reset

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68ae6056c6e8832b9f9e5186f0b1f726