### PR TITLE
Display gold balance in main tab

### DIFF
--- a/Kukulcan/CollectionStore.swift
+++ b/Kukulcan/CollectionStore.swift
@@ -6,6 +6,7 @@ final class CollectionStore: ObservableObject {
     // Persistance locale
     @AppStorage("owned_cards_v2") private var ownedData: Data = Data()
     @AppStorage("player_decks_v1") private var decksData: Data = Data()
+    @AppStorage("player_gold_v1") private var goldStored: Int = 0
 
     // Cartes possédées
     @Published var owned: [Card] = [] {
@@ -17,7 +18,13 @@ final class CollectionStore: ObservableObject {
         didSet { saveDecks() }
     }
 
+    // Monnaie du joueur
+    @Published var gold: Int = 0 {
+        didSet { goldStored = gold }
+    }
+
     init() {
+        gold = goldStored
         load()
         loadDecks()
     }
@@ -121,6 +128,7 @@ final class CollectionStore: ObservableObject {
     func resetCollection() {
         owned.removeAll()
         decks.removeAll()
+        gold = 0
     }
 }
 

--- a/Kukulcan/MainTabView.swift
+++ b/Kukulcan/MainTabView.swift
@@ -32,6 +32,13 @@ struct MainTabView: View {
             }
         }
         .tint(.orange)
+        .overlay(alignment: .topTrailing) {
+            Label("\(collection.gold)", systemImage: "creditcard")
+                .padding(8)
+                .background(.ultraThinMaterial)
+                .clipShape(Capsule())
+                .padding()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Track player gold in `CollectionStore`
- Show current gold with a credit card icon on every tab

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ae6057c71c832b8f204c4f2059bdd5