### PR TITLE
Award gold after battles

### DIFF
--- a/Kukulcan/CollectionStore.swift
+++ b/Kukulcan/CollectionStore.swift
@@ -27,6 +27,11 @@ final class CollectionStore: ObservableObject {
 
     // MARK: - Packs
 
+    /// Gagne de l'or
+    func earnGold(_ amount: Int) {
+        gold = max(gold + amount, 0)
+    }
+
     /// Dépense de l'or du joueur
     func spendGold(_ amount: Int) {
         gold = max(gold - amount, 0)

--- a/Kukulcan/CombatView.swift
+++ b/Kukulcan/CombatView.swift
@@ -7,11 +7,13 @@ struct CombatView: View {
     @StateObject private var engine: GameEngine
     private let aiLevel: Int
     var onWin: ((Int) -> Void)? = nil
+    var onLoss: (() -> Void)? = nil
     @Environment(\.dismiss) private var dismiss
 
-    init(engine: GameEngine? = nil, aiLevel: Int = 1, onWin: ((Int) -> Void)? = nil) {
+    init(engine: GameEngine? = nil, aiLevel: Int = 1, onWin: ((Int) -> Void)? = nil, onLoss: (() -> Void)? = nil) {
         self.aiLevel = aiLevel
         self.onWin = onWin
+        self.onLoss = onLoss
         if let e = engine {
             _engine = StateObject(wrappedValue: e)
         } else {
@@ -146,6 +148,7 @@ struct CombatView: View {
         }
         .onChange(of: engine.p1.hp) { hp in
             if hp <= 0 {
+                onLoss?()
                 dismiss()
             }
         }

--- a/Kukulcan/DeckSelectionView.swift
+++ b/Kukulcan/DeckSelectionView.swift
@@ -11,6 +11,8 @@ struct DeckSelectionView: View {
     @AppStorage("ai_levels_won_mask") private var aiLevelsWonMask: Int = 0
 
     private let levelRewards = Array(CardsDB.gods.prefix(5))
+    private let winGoldReward = 50
+    private let lossGoldReward = 20
 
     var body: some View {
         NavigationStack {
@@ -84,7 +86,8 @@ struct DeckSelectionView: View {
                             p2: PlayerState(name: "IA", deck: StarterFactory.randomDeck())
                         ),
                         aiLevel: lvl,
-                        onWin: { handleWin(level: $0) }
+                        onWin: { handleWin(level: $0) },
+                        onLoss: { handleLoss() }
                     )
                 }
             }
@@ -99,6 +102,7 @@ struct DeckSelectionView: View {
     }
 
     private func handleWin(level: Int) {
+        collection.earnGold(winGoldReward)
         let mask = 1 << (level - 1)
         if aiLevelsWonMask & mask == 0 {
             aiLevelsWonMask |= mask
@@ -108,5 +112,9 @@ struct DeckSelectionView: View {
             let reward = levelRewards[level - 1]
             collection.add([reward])
         }
+    }
+
+    private func handleLoss() {
+        collection.earnGold(lossGoldReward)
     }
 }


### PR DESCRIPTION
## Summary
- Add gold earning to collection store
- Reward players with gold on victory and defeat
- Support loss callbacks in combat view

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ae66ed20b8832b9f872d2b11a798f4