### PR TITLE
Ensure AI manages blood and sacrifice slots

### DIFF
--- a/Kukulcan/CombatView.swift
+++ b/Kukulcan/CombatView.swift
@@ -215,6 +215,17 @@ struct CombatView: View {
                 slotView(for: engine.opponent.godSlot?.base, hp: engine.opponent.godSlot?.currentHP)
             }
 
+            // Sacrifice adverse
+            HStack(spacing: 8) {
+                Text("Sacrifice :").font(.caption)
+                if let inst = engine.opponent.sacrificeSlot {
+                    CardView(card: inst.base, faceUp: true, width: slotCardWidth)
+                        .rotationEffect(.degrees(90))
+                } else {
+                    emptySlot(width: slotCardWidth, height: slotCardHeight)
+                }
+            }
+
             // Lanes adverses
             HStack(spacing: 8) {
                 ForEach(0..<4) { i in

--- a/Kukulcan/Rules.swift
+++ b/Kukulcan/Rules.swift
@@ -134,6 +134,12 @@ final class GameEngine: ObservableObject {
 
     // MARK: setup
     func start(mulligan: Int = 5) {
+        // Réinitialise les zones et ressources pour les deux joueurs
+        p1.sacrificeSlot = nil; p1.godSlot = nil
+        p2.sacrificeSlot = nil; p2.godSlot = nil
+        p1.blood = 0; p1.pendingBonusBlood = 0
+        p2.blood = 0; p2.pendingBonusBlood = 0
+
         // Mélange très simple
         p1.deck.shuffle(); p2.deck.shuffle()
         _ = p1.draw(mulligan); _ = p2.draw(mulligan)
@@ -426,13 +432,16 @@ final class GameEngine: ObservableObject {
     private func performHardAITurn() {
         guard !currentPlayerIsP1 else { return }
         // Tente d'invoquer un dieu, sinon sacrifie pour gagner du sang
-        if let gIdx = current.hand.firstIndex(where: { $0.type == .god }) {
+        if current.godSlot == nil, let gIdx = current.hand.firstIndex(where: { $0.type == .god }) {
             let god = current.hand[gIdx]
             if current.blood >= god.bloodCost {
                 invokeGod(handIndex: gIdx)
             } else if let sac = current.hand.firstIndex(where: { $0.type == .common }) {
                 sacrificeCommon(handIndex: sac)
             }
+        } else if current.blood < 3, let sac = current.hand.firstIndex(where: { $0.type == .common }) {
+            // Accumule du sang en prévision
+            sacrificeCommon(handIndex: sac)
         }
         performMediumAITurn()
     }


### PR DESCRIPTION
## Summary
- Reset blood, sacrifice, and god slots for both players at game start
- Improve AI strategy to sacrifice for blood and handle existing god slots
- Show opponent sacrifice slot in combat view

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68ae67428c50832b9957d4f1de2e61b5