### PR TITLE
Add tests for player gold and stub AppStorage for Linux

### DIFF
--- a/KukulcanTests/KukulcanTests.swift
+++ b/KukulcanTests/KukulcanTests.swift
@@ -123,4 +123,35 @@ struct KukulcanTests {
         #expect(!Deck(name: "gods", cards: [g1, g2]).isValid())
         #expect(Deck(name: "one god", cards: [g1, c1]).isValid())
     }
+
+    /// Gagner de l'or augmente la réserve sans passer en négatif.
+    @Test func earningGoldIncreasesBalance() {
+        let suite = UserDefaults(suiteName: UUID().uuidString)!
+        let store = CollectionStore(store: suite)
+        store.earnGold(10)
+        #expect(store.gold == 10)
+        store.earnGold(-20)
+        #expect(store.gold == 0)
+    }
+
+    /// Dépenser de l'or réduit la réserve mais ne va pas sous zéro.
+    @Test func spendingGoldDecreasesBalance() {
+        let suite = UserDefaults(suiteName: UUID().uuidString)!
+        let store = CollectionStore(store: suite)
+        store.earnGold(10)
+        store.spendGold(4)
+        #expect(store.gold == 6)
+        store.spendGold(10)
+        #expect(store.gold == 0)
+    }
+
+    /// L'or doit persister entre différentes instances de `CollectionStore`.
+    @Test func goldPersistsAcrossInstances() {
+        let suiteName = UUID().uuidString
+        let suite = UserDefaults(suiteName: suiteName)!
+        var store = CollectionStore(store: suite)
+        store.earnGold(5)
+        let reloaded = CollectionStore(store: UserDefaults(suiteName: suiteName)!)
+        #expect(reloaded.gold == 5)
+    }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .target(
             name: "Kukulcan",
             path: "Kukulcan",
-            sources: ["Rules.swift", "Deck.swift"]
+            sources: ["Rules.swift", "Deck.swift", "CollectionStore.swift", "CardsDatabase.swift"]
         ),
         .testTarget(
             name: "KukulcanTests",


### PR DESCRIPTION
## Summary
- add a lightweight `AppStorage` implementation and dependency injection so `CollectionStore` can be tested on Linux
- cover gold earning, spending and persistence in unit tests

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ae684ef234832bbe81778e04593092