### PR TITLE
Display player gold across all screens

### DIFF
--- a/Kukulcan/MainTabView.swift
+++ b/Kukulcan/MainTabView.swift
@@ -4,34 +4,44 @@ struct MainTabView: View {
     @EnvironmentObject var collection: CollectionStore
 
     var body: some View {
-        TabView {
-            PacksView()
-                .tabItem { Label("Accueil", systemImage: "house.fill") }
+        ZStack(alignment: .topTrailing) {
+            TabView {
+                PacksView()
+                    .tabItem { Label("Accueil", systemImage: "house.fill") }
 
-            CollectionView()
-                .tabItem { Label("Collection", systemImage: "square.grid.2x2.fill") }
+                CollectionView()
+                    .tabItem { Label("Collection", systemImage: "square.grid.2x2.fill") }
 
-            if collection.decks.contains(where: { $0.cards.count == 10 }) {
-                DeckSelectionView()
-                    .tabItem { Label("Combats", systemImage: "gamecontroller.fill") }
-            } else {
-                NavigationStack {
-                    VStack(spacing: 16) {
-                        Text("Crée un deck de 10 cartes pour combattre.")
-                            .multilineTextAlignment(.center)
-                        NavigationLink {
-                            DecksView()
-                        } label: {
-                            Label("Créer un deck", systemImage: "plus")
+                if collection.decks.contains(where: { $0.cards.count == 10 }) {
+                    DeckSelectionView()
+                        .tabItem { Label("Combats", systemImage: "gamecontroller.fill") }
+                } else {
+                    NavigationStack {
+                        VStack(spacing: 16) {
+                            Text("Crée un deck de 10 cartes pour combattre.")
+                                .multilineTextAlignment(.center)
+                            NavigationLink {
+                                DecksView()
+                            } label: {
+                                Label("Créer un deck", systemImage: "plus")
+                            }
+                            .buttonStyle(.borderedProminent)
                         }
-                        .buttonStyle(.borderedProminent)
+                        .padding()
                     }
-                    .padding()
+                    .tabItem { Label("Combats", systemImage: "gamecontroller.fill") }
                 }
-                .tabItem { Label("Combats", systemImage: "gamecontroller.fill") }
             }
+            .tint(.orange)
+
+            // Affichage global de l'or du joueur
+            Text("Or : \(collection.gold)")
+                .font(.headline)
+                .padding(8)
+                .background(.ultraThinMaterial)
+                .clipShape(Capsule())
+                .padding()
         }
-        .tint(.orange)
     }
 }
 


### PR DESCRIPTION
## Summary
- overlay gold amount in `MainTabView` for constant visibility

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ae69b53a00832bb41077ce9ac9833c