### PR TITLE
Prevent negative gold adjustments

### DIFF
--- a/Kukulcan/CollectionStore.swift
+++ b/Kukulcan/CollectionStore.swift
@@ -73,11 +73,13 @@ final class CollectionStore: ObservableObject {
 
     /// Gagne de l'or
     func earnGold(_ amount: Int) {
+        guard amount >= 0 else { return }
         gold = max(gold + amount, 0)
     }
 
     /// Dépense de l'or du joueur
     func spendGold(_ amount: Int) {
+        guard amount >= 0 else { return }
         gold = max(gold - amount, 0)
     }
 

--- a/KukulcanTests/KukulcanTests.swift
+++ b/KukulcanTests/KukulcanTests.swift
@@ -131,7 +131,7 @@ struct KukulcanTests {
         store.earnGold(10)
         #expect(store.gold == 10)
         store.earnGold(-20)
-        #expect(store.gold == 0)
+        #expect(store.gold == 10)
     }
 
     /// Dépenser de l'or réduit la réserve mais ne va pas sous zéro.
@@ -140,6 +140,8 @@ struct KukulcanTests {
         let store = CollectionStore(store: suite)
         store.earnGold(10)
         store.spendGold(4)
+        #expect(store.gold == 6)
+        store.spendGold(-3)
         #expect(store.gold == 6)
         store.spendGold(10)
         #expect(store.gold == 0)


### PR DESCRIPTION
## Summary
- Guard gold updates against negative earn/spend amounts
- Test that negative values don't alter the gold balance

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ae6b2a3ce8832b9313e5ca2f45c747