### PR TITLE
Restrict openPack access and use buyPack for pack openings

### DIFF
--- a/Kukulcan/CollectionStore.swift
+++ b/Kukulcan/CollectionStore.swift
@@ -94,7 +94,7 @@ final class CollectionStore: ObservableObject {
     /// Ouvre un pack (mélange commune/rituel/dieu selon `CardsDB.mixedPack`)
     /// et ajoute les cartes tirées à la collection.
     @discardableResult
-    func openPack() -> [Card] {
+    private func openPack() -> [Card] {
         // Toujours 3 cartes : 2 PEUPLE + (1 rituel 40% / sinon 1 PEUPLE) + 20% chance de remplacer par un DIEU
         var result: [Card] = []
         let commons = CardsDB.commons.shuffled()

--- a/Kukulcan/PacksView.swift
+++ b/Kukulcan/PacksView.swift
@@ -49,9 +49,8 @@ struct PacksView: View {
 
                 // Bouton ouvrir
                 Button {
-                    if collection.gold >= packCost {
-                        collection.spendGold(packCost)
-                        lastPulled = collection.openPack()
+                    if let pulled = collection.buyPack(cost: packCost) {
+                        lastPulled = pulled
                         showOpening = true
                     }
                 } label: {

--- a/KukulcanTests/KukulcanTests.swift
+++ b/KukulcanTests/KukulcanTests.swift
@@ -156,4 +156,20 @@ struct KukulcanTests {
         let reloaded = CollectionStore(store: UserDefaults(suiteName: suiteName)!)
         #expect(reloaded.gold == 5)
     }
+
+    /// Acheter un pack consomme l'or et ajoute des cartes à la collection.
+    @Test func buyingPackConsumesGoldAndAddsCards() {
+        let suite = UserDefaults(suiteName: UUID().uuidString)!
+        let store = CollectionStore(store: suite)
+        store.earnGold(100)
+
+        let cards = store.buyPack(cost: 30)
+        #expect(cards?.count == 3)
+        #expect(store.gold == 70)
+        #expect(store.owned.count == 3)
+
+        let failed = store.buyPack(cost: 100)
+        #expect(failed == nil)
+        #expect(store.gold == 70)
+    }
 }


### PR DESCRIPTION
## Summary
- Make `openPack()` private to prevent external calls
- Route pack openings through `buyPack(cost:)` in `PacksView`
- Add test covering gold spending and card acquisition via `buyPack`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68ae6c5531c0832b8a7f871d7752b296