### PR TITLE
Reset gold when resetting collection

### DIFF
--- a/Kukulcan/CollectionStore.swift
+++ b/Kukulcan/CollectionStore.swift
@@ -188,6 +188,7 @@ final class CollectionStore: ObservableObject {
     func resetCollection() {
         owned.removeAll()
         decks.removeAll()
+        gold = 0
     }
 }
 


### PR DESCRIPTION
## Summary
- Reset player's gold to zero when collection is reset

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68ae6d80f06c832bba54027fa9b2e90c