### PR TITLE
Rotate sacrifice cards 180 degrees

### DIFF
--- a/Kukulcan/CombatView.swift
+++ b/Kukulcan/CombatView.swift
@@ -261,7 +261,7 @@ struct CombatView: View {
                 Text("Sacrifice :").font(.caption)
                 if let inst = engine.opponent.sacrificeSlot {
                     CardView(card: inst.base, faceUp: true, width: slotCardWidth)
-                        .rotationEffect(.degrees(90))
+                        .rotationEffect(.degrees(180))
                 } else {
                     emptySlot(width: slotCardWidth, height: slotCardHeight)
                 }
@@ -379,12 +379,12 @@ struct CombatView: View {
 
             VStack(spacing: 6) {
                 Text("Sacrifice").font(.caption).foregroundStyle(.secondary)
-                // visuel tourné à 90° si présent
+                // visuel tourné à 180° si présent
                 if let inst = engine.current.sacrificeSlot {
                     CardView(card: inst.base, faceUp: true, width: slotCardWidth) {
                         selectedCard = inst.base
                     }
-                    .rotationEffect(.degrees(90))
+                    .rotationEffect(.degrees(180))
                     .overlay(Text("+1 Sang").font(.caption2.bold()).padding(4).background(.black.opacity(0.6)).clipShape(Capsule()).foregroundStyle(.white), alignment: .bottom)
                 } else {
                     emptySlot(width: slotCardWidth, height: slotCardHeight)


### PR DESCRIPTION
## Summary
- Flip sacrifice card visuals 180° so they appear upside down relative to normal cards

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68afb41528b4832b9c6ff6870de230c1